### PR TITLE
Remind toggle position

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2276,6 +2276,10 @@
         "2038sorcererHint": "Inclure les capacités et spéciaux la Sorcerer de 2038.",
         "2038necromancer": "Inclure la Necromancer",
         "2038necromancerHint": "Inclure les capacités et spéciaux la Necromancer de 2038."
+      },
+      "TOGGLERS": {
+        "Label": "Réinitialiser les panels pliants",
+        "Hint": "Remet les panels pliants à leur état d'origine sur toutes les fiches."
       }
     },
     "GM":{

--- a/module/helpers/toggler.js
+++ b/module/helpers/toggler.js
@@ -4,6 +4,8 @@ class Toggler {
   }
 
   init(id, html, selector) {
+    id = this._cleanId(id);
+
     html[0].querySelectorAll(selector).forEach((element, index) => {
       const visible = this.toggles.get(this._getKey(id, index));
 
@@ -30,13 +32,19 @@ class Toggler {
   }
 
   clearForId(id) {
+    id = this._cleanId(id);
+
     this.toggles.forEach((value, key) => {
-      if (key.includes(id)) {
+      if (key.startsWith(id)) {
         this.toggles.delete(key);
       }
     });
 
     this._save();
+  }
+
+  _cleanId(id) {
+    return id.split('-').pop();
   }
 
   _getSiblings(element) {

--- a/module/helpers/toggler.js
+++ b/module/helpers/toggler.js
@@ -3,28 +3,25 @@ class Toggler {
     this.toggles = this._load();
   }
 
-  init(id, html, selector) {
+  init(id, html) {
     id = this._cleanId(id);
 
-    html[0].querySelectorAll(selector).forEach((element, index) => {
+    html[0].querySelectorAll('.js-toggler').forEach((element, index) => {
       const visible = this.toggles.get(this._getKey(id, index));
 
       if ('undefined' !== typeof visible) {
         this._getSiblings(element).toggle(visible);
-
-        if (!visible) {
-          this._toggleClasses(element);
-        }
+        this._toggleClasses(element.querySelector('i:first-child'), visible);
       }
 
-      element.addEventListener('click', e => {
+      element.querySelector('i:first-child').addEventListener('click', e => {
         e.preventDefault();
 
         const target = e.currentTarget;
 
         this._toggleClasses(target);
 
-        this._getSiblings(target).toggle({
+        this._getSiblings(element).toggle({
           complete: () => this._setElementVisibility(id, index, element),
         });
       });
@@ -48,12 +45,24 @@ class Toggler {
   }
 
   _getSiblings(element) {
-    return $(element).parents('.header').siblings();
+    return $(element).siblings();
   }
 
-  _toggleClasses(element) {
-    element.classList.toggle('fa-plus-square');
-    element.classList.toggle('fa-minus-square');
+  _toggleClasses(element, forcedVisibility) {
+    if ('undefined' === typeof forcedVisibility) {
+      element.classList.toggle('fa-plus-square');
+      element.classList.toggle('fa-minus-square');
+
+      return;
+    }
+
+    if (forcedVisibility) {
+      element.classList.remove('fa-plus-square');
+      element.classList.add('fa-minus-square');
+    } else {
+      element.classList.add('fa-plus-square');
+      element.classList.remove('fa-minus-square');
+    }
   }
 
   _setElementVisibility(id, index, element) {
@@ -65,7 +74,7 @@ class Toggler {
   }
 
   _getToggleTarget(element) {
-    return element.parentElement.nextElementSibling;
+    return element.nextElementSibling;
   }
 
   _getKey(id, index) {

--- a/module/helpers/toggler.js
+++ b/module/helpers/toggler.js
@@ -1,0 +1,93 @@
+class Toggler {
+  constructor() {
+    this.toggles = this._load();
+  }
+
+  init(id, html, selector) {
+    html[0].querySelectorAll(selector).forEach((element, index) => {
+      const visible = this.toggles.get(this._getKey(id, index));
+
+      if ('undefined' !== typeof visible) {
+        this._getSiblings(element).toggle(visible);
+
+        if (!visible) {
+          this._toggleClasses(element);
+        }
+      }
+
+      element.addEventListener('click', e => {
+        e.preventDefault();
+
+        const target = e.currentTarget;
+
+        this._toggleClasses(target);
+
+        this._getSiblings(target).toggle({
+          complete: () => this._setElementVisibility(id, index, element),
+        });
+      });
+    });
+  }
+
+  clearForId(id) {
+    this.toggles.forEach((value, key) => {
+      if (key.includes(id)) {
+        this.toggles.delete(key);
+      }
+    });
+
+    this._save();
+  }
+
+  _getSiblings(element) {
+    return $(element).parents('.header').siblings();
+  }
+
+  _toggleClasses(element) {
+    element.classList.toggle('fa-plus-square');
+    element.classList.toggle('fa-minus-square');
+  }
+
+  _setElementVisibility(id, index, element) {
+    const target = this._getToggleTarget(element);
+
+    this.toggles.set(this._getKey(id, index), 'none' !== target.style.display);
+
+    this._save();
+  }
+
+  _getToggleTarget(element) {
+    return element.parentElement.nextElementSibling;
+  }
+
+  _getKey(id, index) {
+    return `${id}-${index}`;
+  }
+
+  _save() {
+    const dataset = {};
+
+    this.toggles.forEach((value, key) => {
+      dataset[key] = value;
+    });
+
+    localStorage.setItem('knight.togglers', JSON.stringify(dataset));
+  }
+
+  _load() {
+    const dataset = localStorage.getItem('knight.togglers');
+    if (null === dataset) {
+      return new Map();
+    }
+
+    const map = new Map();
+
+    for (const [key, value] of Object.entries(JSON.parse(dataset))) {
+      map.set(key, value);
+    }
+
+    return map;
+  }
+}
+
+export default new Toggler();

--- a/module/helpers/toggler.js
+++ b/module/helpers/toggler.js
@@ -40,6 +40,12 @@ class Toggler {
     this._save();
   }
 
+  clearAll() {
+    this.toggles = new Map();
+
+    this._save();
+  }
+
   _cleanId(id) {
     return id.split('-').pop();
   }

--- a/module/knight.mjs
+++ b/module/knight.mjs
@@ -37,6 +37,7 @@ import { KnightRollDialog } from "./dialog/roll-dialog.mjs";
 import { KnightEditDialog } from "./dialog/edit-dialog.mjs";
 import { KnightEffetsDialog } from "./dialog/effets-dialog.mjs";
 import { MigrationKnight } from "./migration.mjs";
+import toggler from './helpers/toggler.js';
 
 // GM Helper
 import { GmTool } from "./gm/gmTool.mjs";
@@ -49,7 +50,6 @@ import HooksKnight from "./hooks.mjs";
 /* -------------------------------------------- */
 
 Hooks.once('init', async function() {
-
   // Add utility classes to the global game object so that they're more easily
   // accessible in global contexts.
   game.knight = {
@@ -229,3 +229,6 @@ Hooks.once("ready", async function() {
 });
 
 Hooks.once("ready", HooksKnight.ready);
+
+Hooks.on('deleteItem', doc => toggler.clearForId(doc.id));
+Hooks.on('deleteActor', doc => toggler.clearForId(doc.id));

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -1,3 +1,5 @@
+import toggler from './helpers/toggler.js';
+
 export const RegisterSettings = function () {
     /* ------------------------------------ */
     /* User settings                        */
@@ -83,5 +85,21 @@ export const RegisterSettings = function () {
         config: false,
         type: String,
         default: 0,
+    });
+
+    game.settings.register("knight", "clearTogglers", {
+        name: "KNIGHT.SETTINGS.TOGGLERS.Label",
+        hint: "KNIGHT.SETTINGS.TOGGLERS.Hint",
+        scope: "client",
+        config: true,
+        type: Boolean,
+        default: false,
+        onChange: value => {
+            if (value) {
+                toggler.clearAll();
+
+                game.settings.set('knight', 'clearTogglers', false);
+            }
+        }
     });
 };

--- a/module/sheets/actors/bande-sheet.mjs
+++ b/module/sheets/actors/bande-sheet.mjs
@@ -57,19 +57,7 @@ export class BandeSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
-    //
-    // html.find('header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");
@@ -97,16 +85,6 @@ export class BandeSheet extends ActorSheet {
       };
 
       this.actor.update(update);
-    });
-
-    html.find('.extendButton').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square fa-minus-square");
-
-      if($(ev.currentTarget).hasClass("fa-minus-square")) {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "block");
-      } else {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "none");
-      }
     });
 
     html.find('div.bCapacite img.info').click(ev => {

--- a/module/sheets/actors/bande-sheet.mjs
+++ b/module/sheets/actors/bande-sheet.mjs
@@ -1,4 +1,4 @@
-import { 
+import {
   getEffets,
   getAspectValue,
   getAEValue,
@@ -8,6 +8,7 @@ import {
 } from "../../helpers/common.mjs";
 
 import { KnightRollDialog } from "../../dialog/roll-dialog.mjs";
+import toggler from '../../helpers/toggler.js';
 
 /**
  * @extends {ActorSheet}
@@ -30,12 +31,12 @@ export class BandeSheet extends ActorSheet {
   /** @inheritdoc */
   getData() {
     const context = super.getData();
-    
+
     this._prepareCharacterItems(context);
     this._prepareAE(context);
 
     context.systemData = context.data.system;
-    
+
     return context;
   }
 
@@ -56,17 +57,19 @@ export class BandeSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
 
-    html.find('header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".summary").siblings().toggle();
-    });
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
+    //
+    // html.find('header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
+    // });
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");
@@ -78,7 +81,7 @@ export class BandeSheet extends ActorSheet {
       const option = $(ev.currentTarget).data("option");
       const actuel = this.getData().data.system[option]?.optionDeploy || false;
 
-      let result = false;      
+      let result = false;
       if(actuel) {
         result = false;
       } else {
@@ -96,7 +99,7 @@ export class BandeSheet extends ActorSheet {
       this.actor.update(update);
     });
 
-    html.find('.extendButton').click(ev => {      
+    html.find('.extendButton').click(ev => {
       $(ev.currentTarget).toggleClass("fa-plus-square fa-minus-square");
 
       if($(ev.currentTarget).hasClass("fa-minus-square")) {
@@ -214,7 +217,7 @@ export class BandeSheet extends ActorSheet {
 
       this.actor.update({[`system.options.${option}`]:result});
     });
-    
+
     html.find('.activatePhase2').click(ev => {
       const data = this.getData().data.system;
       const phase2 = data.phase2;
@@ -382,10 +385,10 @@ export class BandeSheet extends ActorSheet {
     itemData = itemData instanceof Array ? itemData : [itemData];
     const itemBaseType = itemData[0].type;
 
-    if(itemBaseType === 'arme' || itemBaseType === 'module' || 
-    itemBaseType === 'armure' || itemBaseType === 'avantage' || 
-    itemBaseType === 'inconvenient' || itemBaseType === 'motivationMineure' || 
-    itemBaseType === 'contact' || itemBaseType === 'blessure' || 
+    if(itemBaseType === 'arme' || itemBaseType === 'module' ||
+    itemBaseType === 'armure' || itemBaseType === 'avantage' ||
+    itemBaseType === 'inconvenient' || itemBaseType === 'motivationMineure' ||
+    itemBaseType === 'contact' || itemBaseType === 'blessure' ||
     itemBaseType === 'trauma' || itemBaseType === 'langue' || itemBaseType === 'armurelegende' ||
     itemBaseType === 'effet') return;
 
@@ -397,7 +400,7 @@ export class BandeSheet extends ActorSheet {
   async _prepareCharacterItems(sheetData) {
     const actorData = sheetData.actor;
     const system = sheetData.data.system;
-    
+
     const capacites = [];
     const aspects = {
       "chair":system.aspects.chair.value,
@@ -563,7 +566,7 @@ export class BandeSheet extends ActorSheet {
               armesContact.push(capaciteWpn);
             } else if(attaque.type === 'distance') {
               armesDistance.push(capaciteWpn);
-            } 
+            }
           }
         } else if(isPhase2 && system.phase2Activate) {
           if(aLieSupp.has) aspectLieSupp.push(aLieSupp.value);
@@ -612,7 +615,7 @@ export class BandeSheet extends ActorSheet {
               armesContact.push(capaciteWpn);
             } else if(attaque.type === 'distance') {
               armesDistance.push(capaciteWpn);
-            } 
+            }
           }
         }
 
@@ -769,7 +772,7 @@ export class BandeSheet extends ActorSheet {
         }
       }
     });
-    
+
     return result;
   }
 
@@ -788,7 +791,7 @@ export class BandeSheet extends ActorSheet {
     await rollApp.setAspects(data.data.system.aspects);
     await rollApp.setEffets(hasBarrage, false, false, false);
     await rollApp.setData(label, select, [], [], difficulte,
-      data.data.system.combat.data.modificateur, data.data.system.combat.data.succesbonus+reussitesBonus, 
+      data.data.system.combat.data.modificateur, data.data.system.combat.data.succesbonus+reussitesBonus,
       {dice:0, fixe:0},
       {dice:0, fixe:0},
       [], [], [], [], {contact:[], distance:[]}, [], [],
@@ -813,7 +816,7 @@ export class BandeSheet extends ActorSheet {
       const aeMajeur = +aspect.ae.majeur.value;
       const lMineur = `KNIGHT.ASPECTS.${key.toUpperCase()}.AE.Mineur`;
       const lMajeur = `KNIGHT.ASPECTS.${key.toUpperCase()}.AE.Majeur`;
-      
+
       if(aeMineur > 0 || aeMajeur > 0) result[key] = {}
 
       if(aeMineur > 0) {
@@ -831,7 +834,7 @@ export class BandeSheet extends ActorSheet {
 
   async _doDebordement(label, dgtsDice) {
     const actor = this.actor;
-   
+
     //DEGATS
     const labelDgt = `${label} : ${game.i18n.localize('KNIGHT.AUTRE.Debordement')}`;
 
@@ -862,18 +865,18 @@ export class BandeSheet extends ActorSheet {
       content: await renderTemplate('systems/knight/templates/dices/wpn.html', pDegats),
       sound: CONFIG.sounds.dice
     };
-    
+
     ChatMessage.create(dgtsMsgData);
   }
 
   async _doDgts(label, dataWpn, listAllEffets, regularite=0, addNum='') {
     const actor = this.actor;
-   
+
     //DEGATS
     const tenebricide = true;
     const bourreau = listAllEffets.bourreau;
     const bourreauValue = listAllEffets.bourreauValue;
-    
+
     const dgtsDice = dataWpn?.dice || 0;
     const dgtsFixe = dataWpn?.fixe || 0;
 
@@ -935,7 +938,7 @@ export class BandeSheet extends ActorSheet {
       content: await renderTemplate('systems/knight/templates/dices/wpn.html', pDegats),
       sound: CONFIG.sounds.dice
     };
-    
+
     ChatMessage.create(dgtsMsgData);
   }
 
@@ -985,7 +988,7 @@ export class BandeSheet extends ActorSheet {
     const lEffetViolence = listEffets.violence;
     const lEffetOther = listEffets.other;
 
-    // ATTAQUE    
+    // ATTAQUE
     const attackDice = lEffetAttack.totalDice;
     const attackBonus = lEffetAttack.totalBonus;
     const attackInclude = lEffetAttack.include;

--- a/module/sheets/actors/creature-sheet.mjs
+++ b/module/sheets/actors/creature-sheet.mjs
@@ -63,19 +63,7 @@ export class CreatureSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
-    //
-    // html.find('header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");
@@ -167,16 +155,6 @@ export class CreatureSheet extends ActorSheet {
 
       span.width($(html).width()/2).css(position, "0px").css(borderRadius, "0px").toggle("display");
       $(ev.currentTarget).toggleClass("clicked");
-    });
-
-    html.find('.extendButton').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square fa-minus-square");
-
-      if($(ev.currentTarget).hasClass("fa-minus-square")) {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "block");
-      } else {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "none");
-      }
     });
 
     html.find('div.bCapacite img.info').click(ev => {

--- a/module/sheets/actors/creature-sheet.mjs
+++ b/module/sheets/actors/creature-sheet.mjs
@@ -8,6 +8,7 @@ import {
 } from "../../helpers/common.mjs";
 
 import { KnightRollDialog } from "../../dialog/roll-dialog.mjs";
+import toggler from '../../helpers/toggler.js';
 
 /**
  * @extends {ActorSheet}
@@ -62,17 +63,19 @@ export class CreatureSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
 
-    html.find('header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".summary").siblings().toggle();
-    });
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
+    //
+    // html.find('header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
+    // });
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");

--- a/module/sheets/actors/ia-sheet.mjs
+++ b/module/sheets/actors/ia-sheet.mjs
@@ -22,7 +22,7 @@ export class IASheet extends ActorSheet {
     this._prepareCharacterItems(context);
 
     context.systemData = context.data.system;
-    
+
     return context;
   }
 
@@ -42,16 +42,6 @@ export class IASheet extends ActorSheet {
   /** @inheritdoc */
   activateListeners(html) {
     super.activateListeners(html);
-
-    html.find('.extendButton').click(ev => {      
-      $(ev.currentTarget).toggleClass("fa-plus-square fa-minus-square");
-
-      if($(ev.currentTarget).hasClass("fa-minus-square")) {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "block");
-      } else {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "none");
-      }
-    });
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;
@@ -84,7 +74,7 @@ export class IASheet extends ActorSheet {
     const data = duplicate(header.dataset);
     // Initialize a default name.
     const name = `${game.i18n.localize(`ITEM.Type${type.capitalize()}`)}`;
-    // Prepare the item object.    
+    // Prepare the item object.
     const itemData = {
       name: name,
       type: type,
@@ -163,9 +153,9 @@ export class IASheet extends ActorSheet {
     itemData = itemData instanceof Array ? itemData : [itemData];
     const itemBaseType = itemData[0].type;
 
-    if(itemBaseType === 'arme' || itemBaseType === 'module' || 
-    itemBaseType === 'armure' || itemBaseType === 'motivationMineure' || 
-    itemBaseType === 'contact' || itemBaseType === 'blessure' || 
+    if(itemBaseType === 'arme' || itemBaseType === 'module' ||
+    itemBaseType === 'armure' || itemBaseType === 'motivationMineure' ||
+    itemBaseType === 'contact' || itemBaseType === 'blessure' ||
     itemBaseType === 'trauma' || itemBaseType === 'langue' || itemBaseType === 'armurelegende' ||
     (itemBaseType === 'avantage' && itemData[0].system.type !== 'ia') ||
     (itemBaseType === 'inconvenient' && itemData[0].system.type !== 'ia') ||
@@ -178,7 +168,7 @@ export class IASheet extends ActorSheet {
 
   async _prepareCharacterItems(sheetData) {
     const actorData = sheetData.actor;7
-    
+
     const avantageIA = [];
     const inconvenientIA = [];
 
@@ -190,7 +180,7 @@ export class IASheet extends ActorSheet {
 
       // INCONVENIENT.
       if (i.type === 'inconvenient') {
-        inconvenientIA.push(i); 
+        inconvenientIA.push(i);
       }
     }
 

--- a/module/sheets/actors/knight-sheet.mjs
+++ b/module/sheets/actors/knight-sheet.mjs
@@ -8,6 +8,7 @@ import {
 } from "../../helpers/common.mjs";
 
 import { KnightRollDialog } from "../../dialog/roll-dialog.mjs";
+import toggler from '../../helpers/toggler.js';
 
 /**
  * @extends {ActorSheet}
@@ -216,17 +217,19 @@ export class KnightSheet extends ActorSheet {
       $(ev.currentTarget).toggleClass("clicked");
     });
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
 
-    html.find('header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".summary").siblings().toggle();
-    });
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
+    //
+    // html.find('header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
+    // });
 
     html.find('img.option').click(ev => {
       const option = $(ev.currentTarget).data("option");

--- a/module/sheets/actors/knight-sheet.mjs
+++ b/module/sheets/actors/knight-sheet.mjs
@@ -217,19 +217,7 @@ export class KnightSheet extends ActorSheet {
       $(ev.currentTarget).toggleClass("clicked");
     });
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
-    //
-    // html.find('header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     html.find('img.option').click(ev => {
       const option = $(ev.currentTarget).data("option");
@@ -251,26 +239,6 @@ export class KnightSheet extends ActorSheet {
       };
 
       this.actor.update(update);
-    });
-
-    html.find('.extendButton').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square fa-minus-square");
-
-      if($(ev.currentTarget).hasClass("fa-minus-square")) {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "block");
-      } else {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "none");
-      }
-    });
-
-    html.find('.extendDescriptionButton').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square fa-minus-square");
-
-      if($(ev.currentTarget).hasClass("fa-minus-square")) {
-        $(ev.currentTarget).parents(".summary").siblings(".description").css("display", "block");
-      } else {
-        $(ev.currentTarget).parents(".summary").siblings(".description").css("display", "none");
-      }
     });
 
     // Everything below here is only needed if the sheet is editable

--- a/module/sheets/actors/mechaarmure-sheet.mjs
+++ b/module/sheets/actors/mechaarmure-sheet.mjs
@@ -58,19 +58,7 @@ export class MechaArmureSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
-    //
-    // html.find('header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");

--- a/module/sheets/actors/mechaarmure-sheet.mjs
+++ b/module/sheets/actors/mechaarmure-sheet.mjs
@@ -9,6 +9,7 @@ import {
 } from "../../helpers/common.mjs";
 
 import { KnightRollDialog } from "../../dialog/roll-dialog.mjs";
+import toggler from '../../helpers/toggler.js';
 
 /**
  * @extends {ActorSheet}
@@ -57,17 +58,19 @@ export class MechaArmureSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
 
-    html.find('header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".summary").siblings().toggle();
-    });
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
+    //
+    // html.find('header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
+    // });
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");

--- a/module/sheets/actors/pnj-sheet.mjs
+++ b/module/sheets/actors/pnj-sheet.mjs
@@ -8,6 +8,7 @@ import {
 } from "../../helpers/common.mjs";
 
 import { KnightRollDialog } from "../../dialog/roll-dialog.mjs";
+import toggler from '../../helpers/toggler.js';
 
 /**
  * @extends {ActorSheet}
@@ -62,17 +63,19 @@ export class PNJSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
 
-    html.find('header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".summary").siblings().toggle();
-    });
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
+    //
+    // html.find('header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
+    // });
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");

--- a/module/sheets/actors/pnj-sheet.mjs
+++ b/module/sheets/actors/pnj-sheet.mjs
@@ -63,19 +63,7 @@ export class PNJSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
-    //
-    // html.find('header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");
@@ -173,16 +161,6 @@ export class PNJSheet extends ActorSheet {
 
       span.width($(html).width()/2).css(position, "0px").css(borderRadius, "0px").toggle("display");
       $(ev.currentTarget).toggleClass("clicked");
-    });
-
-    html.find('.extendButton').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square fa-minus-square");
-
-      if($(ev.currentTarget).hasClass("fa-minus-square")) {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "block");
-      } else {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "none");
-      }
     });
 
     html.find('div.bCapacite img.info').click(ev => {

--- a/module/sheets/actors/vehicule-sheet.mjs
+++ b/module/sheets/actors/vehicule-sheet.mjs
@@ -6,6 +6,7 @@ import {
 } from "../../helpers/common.mjs";
 
 import { KnightRollDialog } from "../../dialog/roll-dialog.mjs";
+import toggler from '../../helpers/toggler.js';
 
 /**
  * @extends {ActorSheet}
@@ -53,17 +54,19 @@ export class VehiculeSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
 
-    html.find('header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".summary").siblings().toggle();
-    });
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
+    //
+    // html.find('header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
+    // });
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");

--- a/module/sheets/actors/vehicule-sheet.mjs
+++ b/module/sheets/actors/vehicule-sheet.mjs
@@ -54,19 +54,7 @@ export class VehiculeSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
-    //
-    // html.find('header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".summary").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     html.find('img.dice').hover(ev => {
       $(ev.currentTarget).attr("src", "systems/knight/assets/icons/D6White.svg");
@@ -94,16 +82,6 @@ export class VehiculeSheet extends ActorSheet {
       };
 
       this.actor.update(update);
-    });
-
-    html.find('.extendButton').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square fa-minus-square");
-
-      if($(ev.currentTarget).hasClass("fa-minus-square")) {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "block");
-      } else {
-        $(ev.currentTarget).parents(".summary").siblings().css("display", "none");
-      }
     });
 
     // Everything below here is only needed if the sheet is editable

--- a/module/sheets/items/arme-sheet.mjs
+++ b/module/sheets/items/arme-sheet.mjs
@@ -61,13 +61,7 @@ export class ArmeSheet extends ItemSheet {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;

--- a/module/sheets/items/arme-sheet.mjs
+++ b/module/sheets/items/arme-sheet.mjs
@@ -1,4 +1,6 @@
 import { listEffects } from "../../helpers/common.mjs";
+import toggler from '../../helpers/toggler.js';
+
 /**
  * @extends {ItemSheet}
  */
@@ -22,7 +24,7 @@ export class ArmeSheet extends ItemSheet {
   getData() {
     const context = super.getData();
     const actor = this.actor;
-    
+
     this._listeRarete(context);
     this._prepareEffets(context);
     this._prepareDistance(context);
@@ -36,7 +38,7 @@ export class ArmeSheet extends ItemSheet {
         const hasMaxEffets = contrecoups.maxeffets.value;
         const hasArmeDistance = contrecoups.armedistance.value;
         context.data.system.restrictions = {};
-        
+
         if(hasMaxEffets) {
           context.data.system.restrictions.contact = {};
           context.data.system.restrictions.contact.has = contrecoups.maxeffets.value;
@@ -49,7 +51,7 @@ export class ArmeSheet extends ItemSheet {
     }
 
     context.systemData = context.data.system;
-    
+
     return context;
   }
 
@@ -59,11 +61,13 @@ export class ArmeSheet extends ItemSheet {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header .far');
+
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;
@@ -155,7 +159,7 @@ export class ArmeSheet extends ItemSheet {
       $(ev.currentTarget).toggleClass("clicked");
     });
   }
-  
+
   async _onDrop(event) {
     const data = TextEditor.getDragEventData(event);
     const cls = getDocumentClass(data?.type);
@@ -173,7 +177,7 @@ export class ArmeSheet extends ItemSheet {
       const violence = document.system.violence;
 
       if(getData.type === 'distance') {
-        if(typeEffet === 'effets' || typeEffet === 'distance') {          
+        if(typeEffet === 'effets' || typeEffet === 'distance') {
           newData.push({
             label:document.name,
             description:document.system.description,
@@ -259,7 +263,7 @@ export class ArmeSheet extends ItemSheet {
           this.item.update({[`system.${typeEffet}.custom`]:update});
         }
       } else if(getData.type === 'contact') {
-        if(typeEffet === 'effets' || typeEffet === 'structurelles' || typeEffet === 'ornementales') {          
+        if(typeEffet === 'effets' || typeEffet === 'structurelles' || typeEffet === 'ornementales') {
           newData.push({
             label:document.name,
             description:document.system.description,
@@ -407,7 +411,7 @@ export class ArmeSheet extends ItemSheet {
       rarObject[rar[i].key] = {};
       rarObject[rar[i].key] = rar[i].label;
     };
-    
+
     context.data.system.listes.rarete = rarObject;
   }
 }

--- a/module/sheets/items/armure-sheet.mjs
+++ b/module/sheets/items/armure-sheet.mjs
@@ -95,13 +95,7 @@ export class ArmureSheet extends ItemSheet {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;

--- a/module/sheets/items/armure-sheet.mjs
+++ b/module/sheets/items/armure-sheet.mjs
@@ -1,5 +1,6 @@
 import { SortByLabel } from "../../helpers/common.mjs";
 import { listEffects } from "../../helpers/common.mjs";
+import toggler from '../../helpers/toggler.js';
 /**
  * @extends {ItemSheet}
  */
@@ -94,11 +95,13 @@ export class ArmureSheet extends ItemSheet {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
+
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;

--- a/module/sheets/items/armurelegende-sheet.mjs
+++ b/module/sheets/items/armurelegende-sheet.mjs
@@ -1,5 +1,6 @@
 import { SortByLabel } from "../../helpers/common.mjs";
 import { listEffects } from "../../helpers/common.mjs";
+import toggler from '../../helpers/toggler.js';
 /**
  * @extends {ItemSheet}
  */
@@ -21,13 +22,13 @@ export class ArmureLegendeSheet extends ItemSheet {
   /** @inheritdoc */
   getData() {
     const context = super.getData();
-    
+
     this._prepareCapacitesTranslation(context);
     this._prepareSpecialTranslation(context);
     this._prepareDurationTranslation(context);
     this._prepareRangeTranslation(context);
     this._createCapaciteList(context);
-    
+
     context.systemData = context.data.system;
 
     return context;
@@ -39,11 +40,13 @@ export class ArmureLegendeSheet extends ItemSheet {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
+
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;
@@ -128,7 +131,7 @@ export class ArmureLegendeSheet extends ItemSheet {
 
       textarea.height(min);
       const height = ev.currentTarget.scrollHeight+1;
-      
+
       textarea.height(Math.max(height, min));
       if(evo) {
         if(special === true) {
@@ -136,7 +139,7 @@ export class ArmureLegendeSheet extends ItemSheet {
         } else {
           this.item.update({[`system.evolutions.liste.${key}.capacites.${capacite}.textarea.${type}`]:Math.max(height, min)});
         }
-        
+
       } else {
         this.item.update({[`system.capacites.selected.${capacite}.textarea.${type}`]:Math.max(height, min)});
       }
@@ -182,7 +185,7 @@ export class ArmureLegendeSheet extends ItemSheet {
 
       textarea.height(min);
       const height = ev.currentTarget.scrollHeight+1;
-      
+
       textarea.height(Math.max(height, min));
       if(evo) {
         if(special === true) {
@@ -190,7 +193,7 @@ export class ArmureLegendeSheet extends ItemSheet {
         } else {
           this.item.update({[`system.evolutions.liste.${key}.capacites.${capacite}.textarea.${type}`]:Math.max(height, min)});
         }
-        
+
       } else {
         this.item.update({[`system.capacites.selected.${capacite}.textarea.${type}`]:Math.max(height, min)});
       }
@@ -283,7 +286,7 @@ export class ArmureLegendeSheet extends ItemSheet {
 
   _prepareGhostSelectedTranslation(context) {
     const degats = context.data.system.capacites.selected?.ghost?.bonus?.degats || false;
- 
+
     if(!degats) return;
 
     const odInclus = game.i18n.localize(CONFIG.KNIGHT.ghost["odinclus"]);
@@ -340,7 +343,7 @@ export class ArmureLegendeSheet extends ItemSheet {
       for (let [keyType, dType] of Object.entries(type.liste)){
         dType.label = game.i18n.localize(CONFIG.KNIGHT.caracteristiques[keyType]);
         labels[key][keyType] = game.i18n.localize(CONFIG.KNIGHT.caracteristiques[keyType]);
-      } 
+      }
     }
   }
 
@@ -409,7 +412,7 @@ export class ArmureLegendeSheet extends ItemSheet {
       const cLEffets = lEffets.contact.coups.effets;
       const cLRaw = cLEffets.raw;
       const cLCustom = cLEffets.custom;
-  
+
       cLEffets.liste = listEffects(cLRaw, cLCustom, labels);
     }
 
@@ -430,18 +433,18 @@ export class ArmureLegendeSheet extends ItemSheet {
   }
 
   _prepareDurationTranslation(context) {
-    const listCapacite = ["changeling", "falcon", "goliath", "ghost", "nanoc", "oriflamme", "shrine", "type", "vision", "puppet", "windtalker", "companions", "totem", "record", "rewind"];    
+    const listCapacite = ["changeling", "falcon", "goliath", "ghost", "nanoc", "oriflamme", "shrine", "type", "vision", "puppet", "windtalker", "companions", "totem", "record", "rewind"];
 
     for(let i = 0;i < listCapacite.length;i++) {
       const capacite = context.data.system.capacites.all[listCapacite[i]];
 
       capacite.duree = game.i18n.localize(CONFIG.KNIGHT[listCapacite[i]].duree);
-      
+
     }
   }
 
   _prepareRangeTranslation(context) {
-    const listCapacite = ["changeling", "mechanic"];    
+    const listCapacite = ["changeling", "mechanic"];
 
     for(let i = 0;i < listCapacite.length;i++) {
       const capacite = context.data.system.capacites.all[listCapacite[i]];

--- a/module/sheets/items/armurelegende-sheet.mjs
+++ b/module/sheets/items/armurelegende-sheet.mjs
@@ -40,13 +40,7 @@ export class ArmureLegendeSheet extends ItemSheet {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;

--- a/module/sheets/items/module-sheet.mjs
+++ b/module/sheets/items/module-sheet.mjs
@@ -1,5 +1,6 @@
 import { SortByLabel } from "../../helpers/common.mjs";
 import { listEffects } from "../../helpers/common.mjs";
+import toggler from '../../helpers/toggler.js';
 /**
  * @extends {ItemSheet}
  */
@@ -39,11 +40,13 @@ export class ModuleSheet extends ItemSheet {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('.header .far').click(ev => {
-      $(ev.currentTarget).toggleClass("fa-plus-square");
-      $(ev.currentTarget).toggleClass("fa-minus-square");
-      $(ev.currentTarget).parents(".header").siblings().toggle();
-    });
+    toggler.init(this.id, html, '.header > .far');
+
+    // html.find('.header .far').click(ev => {
+    //   $(ev.currentTarget).toggleClass("fa-plus-square");
+    //   $(ev.currentTarget).toggleClass("fa-minus-square");
+    //   $(ev.currentTarget).parents(".header").siblings().toggle();
+    // });
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;

--- a/module/sheets/items/module-sheet.mjs
+++ b/module/sheets/items/module-sheet.mjs
@@ -40,13 +40,7 @@ export class ModuleSheet extends ItemSheet {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    toggler.init(this.id, html, '.header > .far');
-
-    // html.find('.header .far').click(ev => {
-    //   $(ev.currentTarget).toggleClass("fa-plus-square");
-    //   $(ev.currentTarget).toggleClass("fa-minus-square");
-    //   $(ev.currentTarget).parents(".header").siblings().toggle();
-    // });
+    toggler.init(this.id, html);
 
     // Everything below here is only needed if the sheet is editable
     if ( !this.isEditable ) return;

--- a/templates/actors/bande-sheet.html
+++ b/templates/actors/bande-sheet.html
@@ -62,7 +62,7 @@
                 </div>
             </div>
             {{/if}}
-            
+
             {{#if systemData.options.blindage}}
             <div class="blindage">
                 <div class="line">
@@ -156,7 +156,7 @@
                     <input class="withBorder" type="number" name="system.reaction.malus.user" min="0" value="{{systemData.reaction.malus.user}}" />
                 </div>
             </div>
-            
+
             <div class="defense">
                 <div class="line">
                     <span class="option {{#unless systemData.defense.optionDeploy}} withBorder {{else}} withoutBorder  {{/unless}}"><img src="systems/knight/assets/icons/option.svg" class="option" data-option="defense"></span>
@@ -279,7 +279,7 @@
 
             {{#if systemData.options.jetsSpeciaux}}
             <div class="jetsSpeciaux">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.ITEMS.MODULE.PNJ.JETSPECIAL.Label"}}
                 </h2>
@@ -295,17 +295,17 @@
 
             {{#unless systemData.options.noCapacites}}
             <div class="capacite">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.CAPACITES.Label"}}
 
                     <a class="item-control item-create" title="Create Item" data-type="capacite"><i class="fas fa-plus"></i></a>
                 </h2>
-                
+
                 {{#each actor.capacites as | key module|}}
                 <div class="bCapacite">
-                    <header class="summary header" data-item-id="{{key._id}}">
-                        <i class="far fa-plus-square extendButton"></i>                        
+                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
+                        <i class="far fa-plus-square extendButton"></i>
 
                         <div class="gestionButton">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -341,7 +341,7 @@
                             {{/if}}
                         </div>
                     </header>
-                    
+
                     <img class="profile-img" style="display:none;" src="{{key.img}}" title="{{key.name}}" />
                     <span class="description" style="display:none;">{{{key.system.description}}}</span>
 
@@ -461,7 +461,7 @@
                                 </div>
                             </div>
                             {{/if}}
- 
+
                         </div>
                     </div>
                 </div>
@@ -470,14 +470,14 @@
             {{/unless}}
 
             <div class="aspectsexceptionnels">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.ASPECTS.Exceptionnels"}}
                 </h2>
 
                 {{#each actor.aspectexceptionnel as | key aspect|}}
                 <div class="data">
-                    <h3 class="header">
+                    <h3 class="header js-toggler">
                         <i class="far fa-plus-square"></i>
 
                         {{getAspect aspect}}
@@ -579,11 +579,11 @@
                                     <option value="{{key}}">{{localize "KNIGHT.AUTRE.Majeur"}} ({{key}})</option>
                                 {{/each}}
                             {{/select}}
-                        </select>                        
+                        </select>
                     </div>
                     {{/each}}
                 </div>
-                
+
             </div>
             {{/if}}
         </div>

--- a/templates/actors/capacites/ascension.html
+++ b/templates/actors/capacites/ascension.html
@@ -1,6 +1,6 @@
 
 <div class="ascension">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ASCENSION.Label"}}
 
@@ -18,7 +18,7 @@
                 {{else}}
                 desactivation
                 {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                " data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="{{@root/systemData/equipements/armure/capacites/ascension/energie}}"
                 data-id="{{this.ascensionId}}" data-depense="{{this.depense}}">
                 {{#unless this.active}}
@@ -43,7 +43,7 @@
                     {{else}}
                     desactivation
                     {{/unless}}
-                    " data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                    " data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-cout="{{@root/systemData/equipements/armure/capacites/ascension/energie}}"
                     data-id="{{this.ascensionId}}" data-depense="{{this.depense}}">
                     {{#unless this.active}}
@@ -64,9 +64,9 @@
             <div class="longspan">
                 <span class="header">{{localize "KNIGHT.LATERAL.Energie"}}</span>
                 <span class="score">
-                    {{{this.energie.min}}} 
-                    - 
-                    {{{this.energie.max}}} 
+                    {{{this.energie.min}}}
+                    -
+                    {{{this.energie.max}}}
                 </span>
             </div>
             <div class="longspan">

--- a/templates/actors/capacites/borealis.html
+++ b/templates/actors/capacites/borealis.html
@@ -1,13 +1,13 @@
 
 <div class="borealis">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.Label"}}
 
         {{#if ("armure" @root/systemData/wear)}}
             <div class="blockMultiline">
                 <label class="allies">
-                    
+
                     <input type="number" name="system.equipements.armure.capacites.borealis.allie" value="{{@root/systemData/equipements/armure/capacites/borealis/allie}}"
                     min="0" />
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.SUPPORT.AllieAffecte"}}</span>

--- a/templates/actors/capacites/cea.html
+++ b/templates/actors/capacites/cea.html
@@ -1,5 +1,5 @@
 <div class="cea">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.Label"}}
     </h3>
@@ -55,7 +55,7 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="col">
             <div class="data">
                 <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.VAGUE.Label"}}</h4>

--- a/templates/actors/capacites/changeling.html
+++ b/templates/actors/capacites/changeling.html
@@ -1,5 +1,5 @@
 <div class="changeling">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.Label"}}
 
@@ -60,7 +60,7 @@
                 min="0" max="{{this.energie.fauxEtre.max}}" />
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.FauxEtres"}}</span>
             </label>
-            
+
             <button class="
                 {{#unless this.active.fauxEtre}}
                 activation

--- a/templates/actors/capacites/companions.html
+++ b/templates/actors/capacites/companions.html
@@ -1,5 +1,5 @@
 <div class="companions">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Label"}}
 
@@ -141,7 +141,7 @@
         </div>
 
         <div class="lion">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.Label"}}
             </h4>
@@ -171,7 +171,7 @@
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
-                    <span>{{this.lion.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.lion.initiative.fixe}}</span>                  
+                    <span>{{this.lion.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.lion.initiative.fixe}}</span>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Armure"}}</h5>
@@ -212,8 +212,8 @@
                 </h5>
                 {{#each this.lion.modules as | kLion module|}}
                 <div class="bModule">
-                    <header class="summary header" data-item-id="{{kLion._id}}">
-                        <i class="far fa-plus-square extendButton"></i>                        
+                    <header class="summary header js-toggler" data-item-id="{{kLion._id}}">
+                        <i class="far fa-plus-square extendButton"></i>
 
                         <div class="gestionButton">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -221,7 +221,7 @@
                         </div>
                         <span>{{{kLion.name}}}</span>
                     </header>
-                    
+
                     <img class="profile-img" style="display:none;" src="{{kLion.img}}" title="{{kLion.name}}" />
                     <span class="description" style="display:none;">{{{kLion.system.description}}}</span>
 
@@ -269,7 +269,7 @@
                                 <span class="textarea">{{{capaciteDescription kLion.system.duree}}}</span>
                                 {{/if}}
                             </div>
-                            
+
                             {{#if kLion.system.bonus.has}}
                             <div class="data">
                                 <h4 class="title">{{localize "KNIGHT.BONUS.Label"}}</h4>
@@ -354,7 +354,7 @@
                                     <span class="header">{{localize "KNIGHT.PORTEE.Label"}}</span>
                                     <span class="score">{{getPortee kLion.system.arme.portee}}</span>
                                 </div>
-                                
+
                                 <h4 class="separation">{{localize "KNIGHT.AUTRE.Degats"}}</h4>
                                 {{#unless kLion.system.arme.degats.variable.has}}
                                 <div class="middlespan noSeparation">
@@ -371,7 +371,7 @@
                                     <span class="score">{{kLion.system.arme.degats.variable.max.dice}}{{localize "KNIGHT.JETS.Des-short"}}6+{{kLion.system.arme.degats.variable.max.fixe}}</span>
                                 </div>
                                 {{/unless}}
-                                
+
                                 <h4 class="separation">{{localize "KNIGHT.AUTRE.Violence"}}</h4>
                                 {{#unless kLion.system.arme.violence.variable.has}}
                                 <div class="middlespan noSeparation">
@@ -543,7 +543,7 @@
         </div>
 
         <div class="wolf">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.Label"}}
             </h4>
@@ -573,7 +573,7 @@
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
-                    <span>{{this.wolf.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.wolf.initiative.fixe}}</span>                
+                    <span>{{this.wolf.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.wolf.initiative.fixe}}</span>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Armure"}}</h5>
@@ -641,7 +641,7 @@
                         <span class="score">{{this.wolf.configurations.medic.bonus.soins}}{{localize "KNIGHT.AUTRE.PointSante-short"}}</span>
                     </div>
                 </div>
-                
+
                 <div class="configuration">
                     <h6>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.TECH.Label"}}</h6>
                     <span>{{{capaciteDescription this.wolf.configurations.tech.description}}}</span>
@@ -706,7 +706,7 @@
         </div>
 
         <div class="crow">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.CROW.Label"}}
             </h4>
@@ -732,7 +732,7 @@
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
-                    <span>{{this.crow.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.crow.initiative.fixe}}</span>                  
+                    <span>{{this.crow.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.crow.initiative.fixe}}</span>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Cohesion"}}</h5>

--- a/templates/actors/capacites/discord.html
+++ b/templates/actors/capacites/discord.html
@@ -1,6 +1,6 @@
 
 <div class="discord">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Label"}}
 
@@ -22,7 +22,7 @@
                 {{localize "KNIGHT.DUREE.UnTour"}} : {{localize "KNIGHT.AUTRE.Desactiver"}}
                 {{/unless}}
             </button>
-            
+
             {{#if this.active.tour}}
             <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="2"
@@ -47,7 +47,7 @@
                 {{localize "KNIGHT.DUREE.ConflitPhase"}} : {{localize "KNIGHT.AUTRE.Desactiver"}}
                 {{/unless}}
             </button>
-            
+
             {{#if this.active.scene}}
             <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="6"

--- a/templates/actors/capacites/falcon.html
+++ b/templates/actors/capacites/falcon.html
@@ -1,6 +1,6 @@
 
 <div class="falcon">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FALCON.Label"}}
 

--- a/templates/actors/capacites/forward.html
+++ b/templates/actors/capacites/forward.html
@@ -1,6 +1,6 @@
 
 <div class="forward">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FORWARD.Label"}}
 

--- a/templates/actors/capacites/ghost.html
+++ b/templates/actors/capacites/ghost.html
@@ -1,6 +1,6 @@
 
 <div class="ghost">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.Label"}}
 

--- a/templates/actors/capacites/goliath.html
+++ b/templates/actors/capacites/goliath.html
@@ -1,6 +1,6 @@
 
 <div class="goliath">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GOLIATH.Label"}}
 

--- a/templates/actors/capacites/illumination.html
+++ b/templates/actors/capacites/illumination.html
@@ -1,6 +1,6 @@
 
 <div class="illumination">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}}
 
@@ -46,7 +46,7 @@
                         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.BLAZE.Label"}} : {{localize "KNIGHT.AUTRE.Desactiver"}}
                         {{/unless}}
                     </button>
-                    
+
                     {{#if this.active.blaze}}
                     <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" data-special="blaze"
                         data-cout="0" data-espoir="{{this.blaze.espoir.prolonger}}">
@@ -181,7 +181,7 @@
                     {{else}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.BLAZE.Label"}} : {{localize "KNIGHT.AUTRE.Choisi"}}
                     {{/unless}}
-                </button>     
+                </button>
 
                 <button class="
                     aChoisir
@@ -207,7 +207,7 @@
                     {{else}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.BEACON.Label"}} : {{localize "KNIGHT.AUTRE.Choisi"}}
                     {{/unless}}
-                </button>     
+                </button>
 
                 <button class="
                     aChoisir
@@ -220,7 +220,7 @@
                     {{else}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.TORCH.Label"}} : {{localize "KNIGHT.AUTRE.Choisi"}}
                     {{/unless}}
-                </button>        
+                </button>
 
                 <button class="
                     aChoisir
@@ -246,7 +246,7 @@
                     {{else}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.LIGHTHOUSE.Label"}} : {{localize "KNIGHT.AUTRE.Choisi"}}
                     {{/unless}}
-                </button>     
+                </button>
 
                 <button class="
                     aChoisir

--- a/templates/actors/capacites/longbow.html
+++ b/templates/actors/capacites/longbow.html
@@ -1,6 +1,6 @@
 
 <div class="longbow">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.Label"}}
     </h3>

--- a/templates/actors/capacites/mechanic.html
+++ b/templates/actors/capacites/mechanic.html
@@ -1,6 +1,6 @@
 
 <div class="mechanic">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Label"}}
 

--- a/templates/actors/capacites/morph.html
+++ b/templates/actors/capacites/morph.html
@@ -1,6 +1,6 @@
 
 <div class="morph">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.Label"}}
 
@@ -123,7 +123,7 @@
 
                     {{#if this.choisi.etirement}}
                     <span class="button">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.ETIREMENT.Label"}} : {{localize "KNIGHT.AUTRE.Choisi"}}</span>
-                    
+
                     <button class="roll" data-label="{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.ETIREMENT.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.ETIREMENT.Immobilisation"}}" data-reussiteBonus="{{this.etirement.bonus}}">
                         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.ETIREMENT.JetImmobilisation"}}
                     </button>
@@ -216,7 +216,7 @@
             <div class="shortspan">
                 <span class="header">{{localize "KNIGHT.ACTIVATION.Label"}}</span>
                 <span class="score">{{getActivation this.activation}}</span>
-            </div>           
+            </div>
             <div class="shortspan">
                 <span class="header">{{localize "KNIGHT.DUREE.Label"}}</span>
                 <span class="score">{{this.duree}}</span>
@@ -351,7 +351,7 @@
                     <span class="header">{{localize "KNIGHT.AUTRE.Violence"}}</span>
                     <span class="score">{{this.polymorphie.canon.violence.dice}}{{localize "KNIGHT.JETS.Des-short"}}6</span>
                 </div>
-            </div>            
+            </div>
             <div class="effets noSeparationTop">
                 {{#each this.polymorphie.canon.effets.liste as | key effet|}}
                     <div>

--- a/templates/actors/capacites/nanoc.html
+++ b/templates/actors/capacites/nanoc.html
@@ -1,5 +1,5 @@
 <div class="nanoc">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.Label"}}
 

--- a/templates/actors/capacites/oriflamme.html
+++ b/templates/actors/capacites/oriflamme.html
@@ -1,6 +1,6 @@
 
 <div class="oriflamme">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ORIFLAMME.Label"}}
 

--- a/templates/actors/capacites/personnalise.html
+++ b/templates/actors/capacites/personnalise.html
@@ -1,5 +1,5 @@
 <div class="personnalise">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{this.label}}
     </h3>

--- a/templates/actors/capacites/puppet.html
+++ b/templates/actors/capacites/puppet.html
@@ -1,6 +1,6 @@
 
 <div class="puppet">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Label"}}
 

--- a/templates/actors/capacites/rage.html
+++ b/templates/actors/capacites/rage.html
@@ -1,6 +1,6 @@
 
 <div class="rage">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.Label"}}
 

--- a/templates/actors/capacites/record.html
+++ b/templates/actors/capacites/record.html
@@ -1,6 +1,6 @@
 
 <div class="record">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RECORD.Label"}}
 

--- a/templates/actors/capacites/rewind.html
+++ b/templates/actors/capacites/rewind.html
@@ -1,6 +1,6 @@
 
 <div class="rewind">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.REWIND.Label"}}
     </h3>

--- a/templates/actors/capacites/sarcophage.html
+++ b/templates/actors/capacites/sarcophage.html
@@ -1,5 +1,5 @@
 <div class="sarcophage">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SARCOPHAGE.Label"}}
     </h3>

--- a/templates/actors/capacites/shrine.html
+++ b/templates/actors/capacites/shrine.html
@@ -1,32 +1,32 @@
 
 <div class="shrine">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.Label"}}
 
         {{#if ("armure" @root/systemData/wear)}}
             <div class="blockMultiline">
             {{#unless this.active.base}}
-                <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-cout="{{this.energie.personnel}}"
                     data-special="personnel">
                     {{localize "KNIGHT.AUTRE.Activer"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel"}}
                 </button>
 
-                <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-cout="{{this.energie.distance}}"
                     data-special="distance">
                     {{localize "KNIGHT.AUTRE.Activer"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance"}}
                 </button>
 
                 {{#if this.energie.acces6tours}}
-                    <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                    <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                         data-cout="{{this.energie.personnel6tours}}"
                         data-special="personnel6">
                         {{localize "KNIGHT.AUTRE.Activer"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel6Tours"}}
                     </button>
 
-                    <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                    <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                         data-cout="{{this.energie.distance6tours}}"
                         data-special="distance6">
                         {{localize "KNIGHT.AUTRE.Activer"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance6Tours"}}
@@ -34,7 +34,7 @@
                 {{/if}}
             {{else}}
                 {{#if this.active.personnel}}
-                    <button class="desactivation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                    <button class="desactivation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-id="{{@root/systemData/equipements/armure/capacites/shrine/id}}"
                     data-special="personnel">
                     {{localize "KNIGHT.AUTRE.Desactiver"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel"}}
@@ -42,7 +42,7 @@
                 {{/if}}
 
                 {{#if this.active.distance}}
-                <button class="desactivation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="desactivation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-id="{{@root/systemData/equipements/armure/capacites/shrine/id}}"
                     data-special="distance">
                     {{localize "KNIGHT.AUTRE.Desactiver"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance"}}
@@ -50,7 +50,7 @@
                 {{/if}}
 
                 {{#if this.active.personnel6}}
-                <button class="desactivation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="desactivation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-id="{{@root/systemData/equipements/armure/capacites/shrine/id}}"
                     data-special="personnel6">
                     {{localize "KNIGHT.AUTRE.Desactiver"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel6Tours"}}
@@ -58,14 +58,14 @@
                 {{/if}}
 
                 {{#if this.active.distance6}}
-                <button class="desactivation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="desactivation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-id="{{@root/systemData/equipements/armure/capacites/shrine/id}}"
                     data-special="distance6">
                     {{localize "KNIGHT.AUTRE.Desactiver"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance6Tours"}}
                 </button>
                 {{/if}}
 
-                <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-id="{{@root/systemData/equipements/armure/capacites/shrine/id}}"
                 data-cout="
                     {{#if this.active.personnel}} {{this.energie.personnel}} {{/if}}

--- a/templates/actors/capacites/totem.html
+++ b/templates/actors/capacites/totem.html
@@ -1,6 +1,6 @@
 
 <div class="totem">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Label"}}
 

--- a/templates/actors/capacites/type.html
+++ b/templates/actors/capacites/type.html
@@ -1,6 +1,6 @@
 
 <div class="type">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.Label"}}
 
@@ -32,7 +32,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.soldier.conflit}}
                     <button class="
                         {{#unless this.type.soldier.horsconflit}}
@@ -98,7 +98,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.hunter.conflit}}
                     <button class="
                         {{#unless this.type.hunter.horsconflit}}
@@ -164,7 +164,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.scholar.conflit}}
                     <button class="
                         {{#unless this.type.scholar.horsconflit}}
@@ -230,7 +230,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.herald.conflit}}
                     <button class="
                         {{#unless this.type.herald.horsconflit}}
@@ -296,7 +296,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.scout.conflit}}
                     <button class="
                         {{#unless this.type.scout.horsconflit}}
@@ -345,7 +345,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                    " data-type="capacites" data-capacite="{{this.key}}" data-special="soldier" 
+                    " data-type="capacites" data-capacite="{{this.key}}" data-special="soldier"
                     data-value="{{this.type.soldier.selectionne}}">
                     {{#unless this.type.soldier.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Soldier"}} : {{localize "KNIGHT.AUTRE.Choisir"}}
@@ -360,7 +360,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}" data-special="hunter" 
+                " data-type="capacites" data-capacite="{{this.key}}" data-special="hunter"
                     data-value="{{this.type.hunter.selectionne}}">
                     {{#unless this.type.hunter.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Hunter"}} : {{localize "KNIGHT.AUTRE.Choisir"}}
@@ -375,7 +375,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}" data-special="scholar" 
+                " data-type="capacites" data-capacite="{{this.key}}" data-special="scholar"
                     data-value="{{this.type.scholar.selectionne}}">
                     {{#unless this.type.scholar.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Scholar"}} : {{localize "KNIGHT.AUTRE.Choisir"}}
@@ -390,7 +390,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}" data-special="herald" 
+                " data-type="capacites" data-capacite="{{this.key}}" data-special="herald"
                     data-value="{{this.type.herald.selectionne}}">
                     {{#unless this.type.herald.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Herald"}} : {{localize "KNIGHT.AUTRE.Choisir"}}
@@ -405,7 +405,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}" data-special="scout" 
+                " data-type="capacites" data-capacite="{{this.key}}" data-special="scout"
                     data-value="{{this.type.scout.selectionne}}">
                     {{#unless this.type.scout.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Scout"}} : {{localize "KNIGHT.AUTRE.Choisir"}}

--- a/templates/actors/capacites/vision.html
+++ b/templates/actors/capacites/vision.html
@@ -1,6 +1,6 @@
 
 <div class="vision">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.VISION.Label"}}
 

--- a/templates/actors/capacites/warlord.html
+++ b/templates/actors/capacites/warlord.html
@@ -1,5 +1,5 @@
 <div class="warlord">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}}
 
@@ -250,7 +250,7 @@
                 </div>
             </div>
         </div>
-        
+
 
         {{#if @root/systemData/equipements/armure/capacites/warlord/modes/action}}
         <div class="data">

--- a/templates/actors/capacites/watchtower.html
+++ b/templates/actors/capacites/watchtower.html
@@ -1,5 +1,5 @@
 <div class="watchtower">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WATCHTOWER.Label"}}
 
@@ -11,7 +11,7 @@
                 {{else}}
                 desactivation
                 {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                " data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="{{this.energie}}">
                 {{#unless @root/systemData/equipements/armure/capacites/watchtower}}
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WATCHTOWER.Label"}} : {{localize "KNIGHT.AUTRE.Activer"}}

--- a/templates/actors/capacites/windtalker.html
+++ b/templates/actors/capacites/windtalker.html
@@ -1,12 +1,12 @@
 
 <div class="windtalker">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WINDTALKER.Label"}}
 
         {{#if ("armure" @root/systemData/wear)}}
         <div class="blockMultiline">
-            <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+            <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="{{this.energie}}" data-flux="{{this.flux}}">
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WINDTALKER.Label"}} : {{localize "KNIGHT.AUTRE.Activer"}}
             </button>

--- a/templates/actors/capacites/zen.html
+++ b/templates/actors/capacites/zen.html
@@ -1,11 +1,11 @@
 <div class="zen">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ZEN.Label"}}
 
         {{#if ("armure" @root/systemData/wear)}}
         <div class="blockMultiline">
-            <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+            <button class="activation" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="0" data-difficulte="{{{this.difficulte}}}" data-caracteristiques="{{#each this.aspects  as | key aspect|}}{{#each key.caracteristiques  as | keyCarac caracteristique|}}{{#if keyCarac.value}}{{caracteristique}}{{/if}}.{{/each}}{{/each}}">
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ZEN.Label"}} : {{localize "KNIGHT.AUTRE.Activer"}}
             </button>

--- a/templates/actors/capacitesLegende/changeling.html
+++ b/templates/actors/capacitesLegende/changeling.html
@@ -1,5 +1,5 @@
 <div class="changeling">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.Label"}}
 
@@ -60,7 +60,7 @@
                 min="0" max="{{this.energie.fauxEtre.max}}" />
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.FauxEtres"}}</span>
             </label>
-            
+
             <button class="
                 {{#unless this.active.fauxEtre}}
                 activationLegende

--- a/templates/actors/capacitesLegende/companions.html
+++ b/templates/actors/capacitesLegende/companions.html
@@ -1,5 +1,5 @@
 <div class="companions">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Label"}}
 
@@ -162,7 +162,7 @@
         </div>
 
         <div class="lion">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.Label"}}
             </h4>
@@ -192,7 +192,7 @@
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
-                    <span>{{this.lion.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.lion.initiative.fixe}}</span>                  
+                    <span>{{this.lion.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.lion.initiative.fixe}}</span>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Armure"}}</h5>
@@ -233,8 +233,8 @@
                 </h5>
                 {{#each this.lion.modules as | kLion module|}}
                 <div class="bModule">
-                    <header class="summary header" data-item-id="{{kLion._id}}">
-                        <i class="far fa-plus-square extendButton"></i>                        
+                    <header class="summary header js-toggler" data-item-id="{{kLion._id}}">
+                        <i class="far fa-plus-square extendButton"></i>
 
                         <div class="gestionButton">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -242,7 +242,7 @@
                         </div>
                         <span>{{{kLion.name}}}</span>
                     </header>
-                    
+
                     <img class="profile-img" style="display:none;" src="{{kLion.img}}" title="{{kLion.name}}" />
                     <span class="description" style="display:none;">{{{kLion.system.description}}}</span>
 
@@ -290,7 +290,7 @@
                                 <span class="textarea">{{{capaciteDescription kLion.system.duree}}}</span>
                                 {{/if}}
                             </div>
-                            
+
                             {{#if kLion.system.bonus.has}}
                             <div class="data">
                                 <h4 class="title">{{localize "KNIGHT.BONUS.Label"}}</h4>
@@ -375,7 +375,7 @@
                                     <span class="header">{{localize "KNIGHT.PORTEE.Label"}}</span>
                                     <span class="score">{{getPortee kLion.system.arme.portee}}</span>
                                 </div>
-                                
+
                                 <h4 class="separation">{{localize "KNIGHT.AUTRE.Degats"}}</h4>
                                 {{#unless kLion.system.arme.degats.variable.has}}
                                 <div class="middlespan noSeparation">
@@ -392,7 +392,7 @@
                                     <span class="score">{{kLion.system.arme.degats.variable.max.dice}}{{localize "KNIGHT.JETS.Des-short"}}6+{{kLion.system.arme.degats.variable.max.fixe}}</span>
                                 </div>
                                 {{/unless}}
-                                
+
                                 <h4 class="separation">{{localize "KNIGHT.AUTRE.Violence"}}</h4>
                                 {{#unless kLion.system.arme.violence.variable.has}}
                                 <div class="middlespan noSeparation">
@@ -564,7 +564,7 @@
         </div>
 
         <div class="wolf">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.Label"}}
             </h4>
@@ -594,7 +594,7 @@
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
-                    <span>{{this.wolf.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.wolf.initiative.fixe}}</span>                
+                    <span>{{this.wolf.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.wolf.initiative.fixe}}</span>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Armure"}}</h5>
@@ -662,7 +662,7 @@
                         <span class="score">{{this.wolf.configurations.medic.bonus.soins}}{{localize "KNIGHT.AUTRE.PointSante-short"}}</span>
                     </div>
                 </div>
-                
+
                 <div class="configuration">
                     <h6>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.TECH.Label"}}</h6>
                     <span>{{{capaciteDescription this.wolf.configurations.tech.description}}}</span>
@@ -727,7 +727,7 @@
         </div>
 
         <div class="crow">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.CROW.Label"}}
             </h4>
@@ -753,7 +753,7 @@
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
-                    <span>{{this.crow.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.crow.initiative.fixe}}</span>                  
+                    <span>{{this.crow.initiative.value}}{{localize "KNIGHT.JETS.Des-short"}}6+{{this.crow.initiative.fixe}}</span>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Cohesion"}}</h5>

--- a/templates/actors/capacitesLegende/discord.html
+++ b/templates/actors/capacitesLegende/discord.html
@@ -1,6 +1,6 @@
 
 <div class="discord">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Label"}}
 
@@ -22,7 +22,7 @@
                 {{localize "KNIGHT.DUREE.UnTour"}} : {{localize "KNIGHT.AUTRE.Desactiver"}}
                 {{/unless}}
             </button>
-            
+
             {{#if this.active.tour}}
             <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="2"
@@ -47,7 +47,7 @@
                 {{localize "KNIGHT.DUREE.ConflitPhase"}} : {{localize "KNIGHT.AUTRE.Desactiver"}}
                 {{/unless}}
             </button>
-            
+
             {{#if this.active.scene}}
             <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="6"

--- a/templates/actors/capacitesLegende/falcon.html
+++ b/templates/actors/capacitesLegende/falcon.html
@@ -1,6 +1,6 @@
 
 <div class="falcon">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FALCON.Label"}}
 

--- a/templates/actors/capacitesLegende/ghost.html
+++ b/templates/actors/capacitesLegende/ghost.html
@@ -1,6 +1,6 @@
 
 <div class="ghost">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.Label"}}
 

--- a/templates/actors/capacitesLegende/goliath.html
+++ b/templates/actors/capacitesLegende/goliath.html
@@ -1,6 +1,6 @@
 
 <div class="goliath">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GOLIATH.Label"}}
 

--- a/templates/actors/capacitesLegende/mechanic.html
+++ b/templates/actors/capacitesLegende/mechanic.html
@@ -1,6 +1,6 @@
 
 <div class="mechanic">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Label"}}
 

--- a/templates/actors/capacitesLegende/nanoc.html
+++ b/templates/actors/capacitesLegende/nanoc.html
@@ -1,5 +1,5 @@
 <div class="nanoc">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.Label"}}
 

--- a/templates/actors/capacitesLegende/oriflamme.html
+++ b/templates/actors/capacitesLegende/oriflamme.html
@@ -1,9 +1,9 @@
 
 <div class="oriflamme">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ORIFLAMME.Label"}}
-        
+
         {{#if ("armure" @root/systemData/wear)}}
         <div class="blockMultiline">
             <button class="degats" data-label="{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ORIFLAMME.Label"}}" data-degats="{{this.degats.dice}}" data-degatsFixe="{{this.degats.fixe}}" data-cout="{{this.energie}}">

--- a/templates/actors/capacitesLegende/personnalise.html
+++ b/templates/actors/capacitesLegende/personnalise.html
@@ -1,5 +1,5 @@
 <div class="personnalise">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{this.label}}
     </h3>

--- a/templates/actors/capacitesLegende/puppet.html
+++ b/templates/actors/capacitesLegende/puppet.html
@@ -1,6 +1,6 @@
 
 <div class="puppet">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Label"}}
 

--- a/templates/actors/capacitesLegende/record.html
+++ b/templates/actors/capacitesLegende/record.html
@@ -1,6 +1,6 @@
 
 <div class="record">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RECORD.Label"}}
 

--- a/templates/actors/capacitesLegende/rewind.html
+++ b/templates/actors/capacitesLegende/rewind.html
@@ -1,6 +1,6 @@
 
 <div class="rewind">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.REWIND.Label"}}
     </h3>

--- a/templates/actors/capacitesLegende/shrine.html
+++ b/templates/actors/capacitesLegende/shrine.html
@@ -1,26 +1,26 @@
 
 <div class="shrine">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.Label"}}
 
         {{#if ("armure" @root/systemData/wear)}}
             <div class="blockMultiline">
             {{#unless this.active.base}}
-                <button class="activationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="activationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-cout="{{this.energie.personnel}}"
                     data-special="personnel">
                     {{localize "KNIGHT.AUTRE.Activer"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel"}}
                 </button>
 
-                <button class="activationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="activationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-cout="{{this.energie.distance}}"
                     data-special="distance">
                     {{localize "KNIGHT.AUTRE.Activer"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance"}}
                 </button>
             {{else}}
                 {{#if this.active.personnel}}
-                    <button class="desactivationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                    <button class="desactivationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-id="{{@root/systemData/equipements/armure/capacites/shrine/id}}"
                     data-special="personnel">
                     {{localize "KNIGHT.AUTRE.Desactiver"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel"}}
@@ -28,14 +28,14 @@
                 {{/if}}
 
                 {{#if this.active.distance}}
-                <button class="desactivationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="desactivationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                     data-id="{{@root/systemData/equipements/armure/capacites/shrine/id}}"
                     data-special="distance">
                     {{localize "KNIGHT.AUTRE.Desactiver"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance"}}
                 </button>
                 {{/if}}
 
-                <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+                <button class="prolonger" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-id="{{@root/systemData/equipements/armure/capacites/shrine/id}}"
                 data-cout="
                     {{#if this.active.personnel}} {{this.energie.personnel}} {{/if}}

--- a/templates/actors/capacitesLegende/totem.html
+++ b/templates/actors/capacitesLegende/totem.html
@@ -1,6 +1,6 @@
 
 <div class="totem">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Label"}}
 

--- a/templates/actors/capacitesLegende/type.html
+++ b/templates/actors/capacitesLegende/type.html
@@ -1,6 +1,6 @@
 
 <div class="type">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.Label"}}
 
@@ -32,7 +32,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.soldier.conflit}}
                     <button class="
                         {{#unless this.type.soldier.horsconflit}}
@@ -98,7 +98,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.hunter.conflit}}
                     <button class="
                         {{#unless this.type.hunter.horsconflit}}
@@ -164,7 +164,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.scholar.conflit}}
                     <button class="
                         {{#unless this.type.scholar.horsconflit}}
@@ -230,7 +230,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.herald.conflit}}
                     <button class="
                         {{#unless this.type.herald.horsconflit}}
@@ -296,7 +296,7 @@
                         {{/unless}}
                     </button>
                     {{/unless}}
-                    
+
                     {{#unless this.type.scout.conflit}}
                     <button class="
                         {{#unless this.type.scout.horsconflit}}
@@ -345,7 +345,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                    " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="soldier" 
+                    " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="soldier"
                     data-value="{{this.type.soldier.selectionne}}">
                     {{#unless this.type.soldier.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Soldier"}} : {{localize "KNIGHT.AUTRE.Choisir"}}
@@ -360,7 +360,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="hunter" 
+                " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="hunter"
                     data-value="{{this.type.hunter.selectionne}}">
                     {{#unless this.type.hunter.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Hunter"}} : {{localize "KNIGHT.AUTRE.Choisir"}}
@@ -375,7 +375,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="scholar" 
+                " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="scholar"
                     data-value="{{this.type.scholar.selectionne}}">
                     {{#unless this.type.scholar.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Scholar"}} : {{localize "KNIGHT.AUTRE.Choisir"}}
@@ -390,7 +390,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="herald" 
+                " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="herald"
                     data-value="{{this.type.herald.selectionne}}">
                     {{#unless this.type.herald.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Herald"}} : {{localize "KNIGHT.AUTRE.Choisir"}}
@@ -405,7 +405,7 @@
                     {{else}}
                     choisi
                     {{/unless}}
-                " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="scout" 
+                " data-type="capacites" data-capacite="{{this.key}}Legende" data-special="scout"
                     data-value="{{this.type.scout.selectionne}}">
                     {{#unless this.type.scout.selectionne}}
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TYPE.Scout"}} : {{localize "KNIGHT.AUTRE.Choisir"}}

--- a/templates/actors/capacitesLegende/vision.html
+++ b/templates/actors/capacitesLegende/vision.html
@@ -1,6 +1,6 @@
 
 <div class="vision">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.VISION.Label"}}
 

--- a/templates/actors/capacitesLegende/warlord.html
+++ b/templates/actors/capacitesLegende/warlord.html
@@ -1,5 +1,5 @@
 <div class="warlord">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}}
 
@@ -240,7 +240,7 @@
                 </div>
             </div>
         </div>
-        
+
 
         {{#if @root/systemData/equipements/armure/capacites/warlord/modes/action}}
         <div class="data">

--- a/templates/actors/capacitesLegende/windtalker.html
+++ b/templates/actors/capacitesLegende/windtalker.html
@@ -1,12 +1,12 @@
 
 <div class="windtalker">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WINDTALKER.Label"}}
 
         {{#if ("armure" @root/systemData/wear)}}
         <div class="blockMultiline">
-            <button class="activationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}" 
+            <button class="activationLegende" data-type="capacites" data-capacite="{{this.key}}" data-name="{{this.label}}"
                 data-cout="{{this.energie}}" data-flux="{{this.flux}}">
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WINDTALKER.Label"}} : {{localize "KNIGHT.AUTRE.Activer"}}
             </button>

--- a/templates/actors/creature-sheet.html
+++ b/templates/actors/creature-sheet.html
@@ -278,7 +278,7 @@
             {{/if}}
 
             <div class="capacite">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.CAPACITES.Label"}}
 
@@ -287,7 +287,7 @@
 
                 {{#each actor.capacites as | key module|}}
                 <div class="bCapacite">
-                    <header class="summary header" data-item-id="{{key._id}}">
+                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
                         <i class="far fa-plus-square extendButton"></i>
 
                         <div class="gestionButton">
@@ -632,14 +632,14 @@
             {{/if}}
 
             <div class="aspectsexceptionnels">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.ASPECTS.Exceptionnels"}}
                 </h2>
 
                 {{#each actor.aspectexceptionnel as | key aspect|}}
                 <div class="data">
-                    <h3 class="header">
+                    <h3 class="header js-toggler">
                         <i class="far fa-plus-square"></i>
 
                         {{getAspect aspect}}
@@ -691,13 +691,13 @@
 
             <div class="main">
                 <div class="armesImprovisees">
-                    <h2 class="header">
-                        <i class="far fa-plus-square"></i>
+                    <h2 class="header js-toggler">
+                        <i class="far fa-minus-square"></i>
                         {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.LabelContact"}}
                     </h2>
                     {{#each systemData.combat.armesimprovisees.liste as | kAI armesimprovisees|}}
                         <div class="block">
-                            <h3 class="header">
+                            <h3 class="header js-toggler">
                                 <i class="far fa-plus-square"></i>
                                 {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.Chair"}} : {{#each kAI.chair as | kChair chair|}} {{#unless @first}}/{{/unless}} {{kChair}}{{/each}}
                             </h3>
@@ -734,7 +734,7 @@
                     </h2>
                     {{#each systemData.combat.armesimprovisees.liste as | kAI armesimprovisees|}}
                         <div class="block">
-                            <h3 class="header">
+                            <h3 class="header js-toggler">
                                 <i class="far fa-plus-square"></i>
                                 {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.Chair"}} : {{#each kAI.chair as | kChair chair|}} {{#unless @first}}/{{/unless}} {{kChair}}{{/each}}
                             </h3>

--- a/templates/actors/ia-sheet.html
+++ b/templates/actors/ia-sheet.html
@@ -35,7 +35,7 @@
                 </h2>
                 {{#each actor.avantages as | key avantages|}}
                 <div class="block">
-                    <header class="summary header" data-item-id="{{key._id}}">
+                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
                         <i class="far fa-plus-square extendButton"></i>
                         <div class="gestionButton">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -57,7 +57,7 @@
                 </h2>
                 {{#each actor.inconvenient as | key inconvenient|}}
                 <div class="block">
-                    <header class="summary header" data-item-id="{{key._id}}">
+                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
                         <i class="far fa-plus-square extendButton"></i>
                         <div class="gestionButton">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>

--- a/templates/actors/knight-sheet.html
+++ b/templates/actors/knight-sheet.html
@@ -389,7 +389,7 @@
                     </h2>
                     {{#each actor.avantages as | key avantages|}}
                     <div class="block">
-                        <header class="summary header" data-item-id="{{key._id}}">
+                        <header class="summary header js-toggler" data-item-id="{{key._id}}">
                             <i class="far fa-plus-square extendButton"></i>
                             <div class="gestionButton">
                                 <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -411,7 +411,7 @@
                     </h2>
                     {{#each actor.inconvenient as | key inconvenient|}}
                     <div class="block">
-                        <header class="summary header" data-item-id="{{key._id}}">
+                        <header class="summary header js-toggler" data-item-id="{{key._id}}">
                             <i class="far fa-plus-square extendButton"></i>
                             <div class="gestionButton">
                                 <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -435,7 +435,7 @@
                     </h2>
                     {{#each actor.carteHeroique as | key heroisme|}}
                     <div class="block">
-                        <header class="summary header" data-item-id="{{key._id}}">
+                        <header class="summary header js-toggler" data-item-id="{{key._id}}">
                             <i class="far fa-plus-square extendButton"></i>
                             <div class="gestionButton">
                                 <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -457,7 +457,7 @@
                     </h2>
                     {{#each actor.capaciteHeroique as | key heroisme|}}
                     <div class="block">
-                        <header class="summary header" data-item-id="{{key._id}}">
+                        <header class="summary header js-toggler" data-item-id="{{key._id}}">
                             <i class="far fa-plus-square extendButton"></i>
                             <div class="gestionButton">
                                 <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -521,7 +521,7 @@
             <section class="tabArmure">
                 <div class="tab-armure MAarmure {{#if systemData.MATabs.MAarmure}}active{{/if}}">
                     <div class="capacites">
-                        <h2 class="header">
+                        <h2 class="header js-toggler">
                             <i class="far fa-minus-square"></i>
                             {{localize "KNIGHT.CAPACITES.Label"}}
                         </h2>
@@ -531,7 +531,7 @@
                     </div>
 
                     <div class="special">
-                        <h2 class="header">
+                        <h2 class="header js-toggler">
                             <i class="far fa-minus-square"></i>
                             {{localize "KNIGHT.ITEMS.ARMURE.Special"}}
                         </h2>
@@ -542,7 +542,7 @@
 
                     {{#unless (isEmpty actor.armureLegendeData)}}
                     <div class="capacites capacitesLegende">
-                        <h2 class="header">
+                        <h2 class="header js-toggler">
                             <i class="far fa-minus-square"></i>
                             {{localize "ITEM.TypeArmurelegende"}} : {{localize "KNIGHT.CAPACITES.Label"}}
                         </h2>
@@ -554,7 +554,7 @@
 
                     {{#unless (isEmpty actor.armureLegendeData)}}
                     <div class="capacites specialLegende">
-                        <h2 class="header">
+                        <h2 class="header js-toggler">
                             <i class="far fa-minus-square"></i>
                             {{localize "ITEM.TypeArmurelegende"}} : {{localize "KNIGHT.ITEMS.ARMURE.Special"}}
                         </h2>
@@ -565,7 +565,7 @@
                     {{/unless}}
 
                     <div class="overdrives">
-                        <h2 class="header">
+                        <h2 class="header js-toggler">
                             <i class="far fa-minus-square"></i>
                             {{localize "KNIGHT.ITEMS.ARMURE.Overdrives"}}
                         </h2>
@@ -573,7 +573,7 @@
                         {{#each actor.overdrives as | kAspect aspect|}}
                             {{#each kAspect as | kCarac carac|}}
                                 <div class="data">
-                                    <h3 class="header">
+                                    <h3 class="header js-toggler">
                                         <i class="far fa-plus-square"></i>
 
                                         {{getCarac carac}}
@@ -592,7 +592,7 @@
 
                 <div class="tab-armure MAmodule {{#if systemData.MATabs.MAmodule}}active{{/if}}">
                     <div class="slots">
-                        <h2 class="header">
+                        <h2 class="header js-toggler">
                             <i class="far fa-minus-square"></i>
                             {{localize "KNIGHT.ITEMS.ARMURE.SLOTS.Label"}}
                         </h2>
@@ -643,7 +643,7 @@
                     </div>
 
                     <div class="modules">
-                        <h2 class="header">
+                        <h2 class="header js-toggler">
                             <i class="far fa-minus-square"></i>
                             {{localize "KNIGHT.ITEMS.MODULE.Label"}}
 
@@ -652,7 +652,7 @@
 
                         {{#each actor.modules as | key module|}}
                         <div class="bModule">
-                            <header class="summary header" data-item-id="{{key._id}}">
+                            <header class="summary header js-toggler" data-item-id="{{key._id}}">
                                 <i class="far fa-plus-square extendButton"></i>
 
                                 <div class="gestionButton">
@@ -1212,7 +1212,7 @@
                                 </h2>
                                 {{#each actor.avantagesIA as | key avantages|}}
                                 <div class="block">
-                                    <header class="summary header" data-item-id="{{key._id}}">
+                                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
                                         <i class="far fa-plus-square extendButton"></i>
                                         <div class="gestionButton">
                                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -1243,7 +1243,7 @@
                                 </h2>
                                 {{#each actor.inconvenientIA as | key inconvenient|}}
                                 <div class="block">
-                                    <header class="summary header" data-item-id="{{key._id}}">
+                                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
                                         <i class="far fa-plus-square extendButton"></i>
                                         <div class="gestionButton">
                                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -1340,13 +1340,13 @@
 
             <div class="main">
                 <div class="armesImprovisees">
-                    <h2 class="header">
-                        <i class="far fa-plus-square"></i>
+                    <h2 class="header js-toggler">
+                        <i class="far fa-minus-square"></i>
                         {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.LabelContact"}}
                     </h2>
                     {{#each systemData.combat.armesimprovisees.liste as | kAI armesimprovisees|}}
                         <div class="block">
-                            <h3 class="header">
+                            <h3 class="header js-toggler">
                                 <i class="far fa-plus-square"></i>
                                 {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.ODForce"}} : {{kAI.force}}
                             </h3>
@@ -1383,7 +1383,7 @@
                     </h2>
                     {{#each systemData.combat.armesimprovisees.liste as | kAI armesimprovisees|}}
                         <div class="block">
-                            <h3 class="header">
+                            <h3 class="header js-toggler">
                                 <i class="far fa-plus-square"></i>
                                 {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.ODForce"}} : {{kAI.force}}
                             </h3>
@@ -1418,7 +1418,7 @@
             <div class="main">
                 {{#unless (ascension systemData.wear)}}
                 <div class="grenades">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-minus-square"></i>
                         {{localize "KNIGHT.COMBAT.GRENADES.Label"}}
                         <div class="headerQuantity">
@@ -1521,7 +1521,7 @@
                     </h2>
                     {{#each actor.contact as | key contact|}}
                     <div class="block">
-                        <header class="summary" data-item-id="{{key._id}}">
+                        <header class="summary js-toggler" data-item-id="{{key._id}}">
                             <i class="far fa-plus-square extendButton"></i>
                             <div class="gestionButton">
                                 <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -1543,7 +1543,7 @@
                     </h2>
                     {{#each actor.blessure as | key blessure|}}
                     <div class="block">
-                        <header class="summary" data-item-id="{{key._id}}">
+                        <header class="summary js-toggler" data-item-id="{{key._id}}">
                             <i class="far fa-plus-square extendButton"></i>
                             <div class="gestionButton">
                                 <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -1565,7 +1565,7 @@
                     </h2>
                     {{#each actor.trauma as | key trauma|}}
                     <div class="block">
-                        <header class="summary" data-item-id="{{key._id}}">
+                        <header class="summary js-toggler" data-item-id="{{key._id}}">
                             <i class="far fa-plus-square extendDescriptionButton"></i>
                             <div class="gestionButton">
                                 <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -1658,7 +1658,7 @@
                 {{/unless}}
 
                 <div class="tableauPG">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-minus-square"></i>
                         {{localize "KNIGHT.PROGRESSION.GLOIRE.ListeDepense"}}
                     </h2>
@@ -1698,7 +1698,7 @@
                 </div>
 
                 <div class="tableauPX">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-minus-square"></i>
                         {{localize "KNIGHT.PROGRESSION.EXPERIENCE.ListeDepense"}}
                         <a class="experience-create" title="Create Item"><i class="fas fa-plus"></i></a>

--- a/templates/actors/mechaarmure-sheet.html
+++ b/templates/actors/mechaarmure-sheet.html
@@ -13,7 +13,7 @@
                     <span class="label">
                         {{localize "KNIGHT.MECHAARMURE.Pilote"}}
                     </span>
-                    
+
                     {{#unless (isEmpty actor.pilote)}}
                         <span class="value">
                             {{actor.pilote.surnom}} ({{actor.pilote.name}})
@@ -96,7 +96,7 @@
                     <input type="number" class="withBorder" name="system.champDeForce.base" data-type="champDeForce" min="0" value="{{systemData.champDeForce.base}}" />
                 </div>
             </div>
-            
+
             {{#unless systemData.options.noEnergie}}
             <div class="energie">
                 <div class="line">
@@ -118,14 +118,14 @@
                     <span class="score withBorder">{{systemData.reaction.value}}</span>
                 </div>
             </div>
-            
+
             <div class="defense">
                 <div class="line">
                     <span class="label withBorder">{{localize "KNIGHT.LATERAL.Defense"}}</span>
                     <span class="score withBorder">{{systemData.defense.value}}</span>
                 </div>
-            </div>    
-            {{/unless}}        
+            </div>
+            {{/unless}}
 
             {{#unless systemData.options.noInitiative}}
             <div class="initiative">
@@ -328,7 +328,7 @@
 
                 {{#unless systemData.options.isPod}}
                 <div class="modules">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-minus-square"></i>
                         {{localize "KNIGHT.MECHAARMURE.MODULES.BASE.Label"}}
                     </h2>
@@ -343,7 +343,7 @@
 
                 {{#if (isValue systemData.configurations.actuel 'c1')}}
                 <div class="modules">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-minus-square"></i>
                         {{#if (isValue systemData.configurations.liste.c1.name "")}}
                         {{localize "KNIGHT.MECHAARMURE.CONFIGURATIONS.NomC1"}}
@@ -363,7 +363,7 @@
 
                 {{#if (isValue systemData.configurations.actuel 'c2')}}
                 <div class="modules">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-minus-square"></i>
                         {{#if (isValue systemData.configurations.liste.c2.name "")}}
                         {{localize "KNIGHT.MECHAARMURE.CONFIGURATIONS.NomC2"}}
@@ -382,7 +382,7 @@
                 {{/if}}
 
                 <div class="armesImprovisees">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-plus-square"></i>
                         {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.LabelContact"}}
                     </h2>
@@ -402,10 +402,10 @@
                                         <span>{{key.violence.dice}}{{localize "KNIGHT.JETS.Des-short"}}6</span>
                                     </div>
 
-                                    <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn" 
+                                    <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn"
                                     data-id="contact"
-                                    data-name="{{armesimprovisees}}" 
-                                    data-isDistance="armesimprovisees" 
+                                    data-name="{{armesimprovisees}}"
+                                    data-isDistance="armesimprovisees"
                                     data-num="{{arme}}" data-caracteristiques="{{@root/systemData/combat/armesimprovisees/contact}},force" />
                                 </div>
                             </div>
@@ -414,7 +414,7 @@
                 </div>
 
                 <div class="armesImprovisees">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-plus-square"></i>
                         {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.LabelDistance"}}
                     </h2>
@@ -434,9 +434,9 @@
                                         <span>{{key.violence.dice}}{{localize "KNIGHT.JETS.Des-short"}}6</span>
                                     </div>
 
-                                    <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn" 
-                                    data-id="distance" 
-                                    data-name="{{armesimprovisees}}" 
+                                    <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn"
+                                    data-id="distance"
+                                    data-name="{{armesimprovisees}}"
                                     data-isDistance="armesimprovisees" data-num="{{arme}}"
                                     data-caracteristiques="{{@root/systemData/combat/armesimprovisees/distance}},force" />
                                 </div>
@@ -448,15 +448,15 @@
 
                 {{#if systemData.options.isPod}}
                 <div class="modules">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-minus-square"></i>
                         {{localize "KNIGHT.MECHAARMURE.MODULES.PODMIRACLE.Label"}}
                     </h2>
-                    
+
                     <div class="blockModule">
                         <h3 class="header">
                             {{localize "KNIGHT.MECHAARMURE.MODULES.PODMIRACLE.RecuperationPS"}}
-    
+
                             <div class="blockMultiline">
                                 <button class="podmiracle" data-type="recuperationps">
                                     {{localize "KNIGHT.AUTRE.Activer"}}
@@ -468,7 +468,7 @@
                     <div class="blockModule">
                         <h3 class="header">
                             {{localize "KNIGHT.MECHAARMURE.MODULES.PODMIRACLE.RecuperationPA"}}
-    
+
                             <div class="blockMultiline">
                                 <button class="podmiracle" data-type="recuperationpa">
                                     {{localize "KNIGHT.AUTRE.Activer"}}
@@ -480,7 +480,7 @@
                     <div class="blockModule">
                         <h3 class="header">
                             {{localize "KNIGHT.MECHAARMURE.MODULES.PODMIRACLE.RecuperationBlindage"}}
-    
+
                             <div class="blockMultiline">
                                 <button class="podmiracle" data-type="recuperationblindage">
                                     {{localize "KNIGHT.AUTRE.Activer"}}
@@ -492,7 +492,7 @@
                     <div class="blockModule">
                         <h3 class="header">
                             {{localize "KNIGHT.MECHAARMURE.MODULES.PODMIRACLE.RecuperationResilience"}}
-    
+
                             <div class="blockMultiline">
                                 <button class="podmiracle" data-type="recuperationresilience">
                                     {{localize "KNIGHT.AUTRE.Activer"}}
@@ -504,7 +504,7 @@
                     <div class="blockModule">
                         <h3 class="header">
                             {{localize "KNIGHT.MECHAARMURE.MODULES.PODMIRACLE.Destruction"}}
-    
+
                             <div class="blockMultiline">
                                 <button class="podmiracle" data-type="destruction">
                                     {{localize "KNIGHT.AUTRE.Activer"}}
@@ -530,7 +530,7 @@
                 </label>
             </div>
             <div class="modules">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.MECHAARMURE.MODULES.BASE.Label"}}
                 </h2>
@@ -556,7 +556,7 @@
             </div>
 
             <div class="modules">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{#if (isValue systemData.configurations.liste.c1.name "")}}
                     {{localize "KNIGHT.MECHAARMURE.CONFIGURATIONS.NomC1"}}
@@ -586,7 +586,7 @@
             </div>
 
             <div class="modules">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{#if (isValue systemData.configurations.liste.c2.name "")}}
                     {{localize "KNIGHT.MECHAARMURE.CONFIGURATIONS.NomC2"}}

--- a/templates/actors/mechaarmure/bouclierAmrita.html
+++ b/templates/actors/mechaarmure/bouclierAmrita.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/canonMagma.html
+++ b/templates/actors/mechaarmure/canonMagma.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/canonMetatron.html
+++ b/templates/actors/mechaarmure/canonMetatron.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/canonNoe.html
+++ b/templates/actors/mechaarmure/canonNoe.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/chocSonique.html
+++ b/templates/actors/mechaarmure/chocSonique.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/curse.html
+++ b/templates/actors/mechaarmure/curse.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/dronesAirain.html
+++ b/templates/actors/mechaarmure/dronesAirain.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/dronesEvacuation.html
+++ b/templates/actors/mechaarmure/dronesEvacuation.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/lamesCinetiquesGeantes.html
+++ b/templates/actors/mechaarmure/lamesCinetiquesGeantes.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/missilesJericho.html
+++ b/templates/actors/mechaarmure/missilesJericho.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/mitrailleusesSurtur.html
+++ b/templates/actors/mechaarmure/mitrailleusesSurtur.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/modeSiegeTower.html
+++ b/templates/actors/mechaarmure/modeSiegeTower.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/moduleEmblem.html
+++ b/templates/actors/mechaarmure/moduleEmblem.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/moduleInferno.html
+++ b/templates/actors/mechaarmure/moduleInferno.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">
@@ -43,7 +43,7 @@
         <div class="longspan">
             <span class="label">{{localize "KNIGHT.DUREE.Label"}}</span>
             <span class="value">{{getDuree this.duree}}</span>
-        </div>        
+        </div>
     </div>
     {{/unless}}
 </div>

--- a/templates/actors/mechaarmure/moduleWraith.html
+++ b/templates/actors/mechaarmure/moduleWraith.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/nanoBrume.html
+++ b/templates/actors/mechaarmure/nanoBrume.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/offering.html
+++ b/templates/actors/mechaarmure/offering.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/podInvulnerabilite.html
+++ b/templates/actors/mechaarmure/podInvulnerabilite.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/podMiracle.html
+++ b/templates/actors/mechaarmure/podMiracle.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/poingsSoniques.html
+++ b/templates/actors/mechaarmure/poingsSoniques.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/sautMarkIV.html
+++ b/templates/actors/mechaarmure/sautMarkIV.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/souffleDemoniaque.html
+++ b/templates/actors/mechaarmure/souffleDemoniaque.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/stationDefenseAutomatise.html
+++ b/templates/actors/mechaarmure/stationDefenseAutomatise.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/tourellesLasersAutomatisees.html
+++ b/templates/actors/mechaarmure/tourellesLasersAutomatisees.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/vagueSoin.html
+++ b/templates/actors/mechaarmure/vagueSoin.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/mechaarmure/volMarkIV.html
+++ b/templates/actors/mechaarmure/volMarkIV.html
@@ -1,8 +1,8 @@
 <div class="blockModule">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{{getMAModule this.key}}}
-        
+
         {{#if this.config}}
         <div>
             <a class="delete supprimerModule" data-type="{{this.type}}" data-value="{{this.key}}">

--- a/templates/actors/pnj-sheet.html
+++ b/templates/actors/pnj-sheet.html
@@ -13,12 +13,12 @@
                     <span>{{localize "KNIGHT.Surnom"}} : </span>
                     <input type="text" name="system.surnom" value="{{systemData.surnom}}" />
                 </label>
-    
+
                 <label>
                     <span>{{localize "KNIGHT.Archetype"}} : </span>
                     <input type="text" name="system.archetype" value="{{systemData.archetype}}" />
                 </label>
-    
+
                 <label>
                     <span>{{localize "KNIGHT.Age"}} : </span>
                     <input type="text" name="system.age" value="{{systemData.age}}" />
@@ -28,17 +28,17 @@
                     <span>{{localize "KNIGHT.ARMURE.Label"}} : </span>
                     <input type="text" name="system.wear" value="{{systemData.wear}}" />
                 </label>
-    
+
                 <label>
                     <span>{{localize "KNIGHT.Section"}} : </span>
                     <input type="text" name="system.section" value="{{systemData.section}}" />
                 </label>
-    
+
                 <label>
                     <span>{{localize "KNIGHT.Blason"}} : </span>
                     <input type="text" name="system.blason" value="{{systemData.blason}}" />
                 </label>
-    
+
                 <label>
                     <span>{{localize "KNIGHT.HautFait"}} : </span>
                     <input type="text" name="system.hautFait" value="{{systemData.hautFait}}" />
@@ -221,7 +221,7 @@
                     <input class="withBorder" type="number" name="system.reaction.malus.user" min="0" value="{{systemData.reaction.malus.user}}" />
                 </div>
             </div>
-            
+
             <div class="defense">
                 <div class="line">
                     <span class="option {{#unless systemData.defense.optionDeploy}} withBorder {{else}} withoutBorder  {{/unless}}"><img src="systems/knight/assets/icons/option.svg" class="option" data-option="defense"></span>
@@ -353,7 +353,7 @@
 
             {{#if systemData.options.wolfConfiguration}}
             <div class="wolf">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.Label"}}
                 </h2>
@@ -366,11 +366,11 @@
                         <div class="blockMultiline">
                             <button class="wolfFighter" data-label="{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.FIGHTER.Label"}}">
                                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.FIGHTER.Label"}} : {{localize "KNIGHT.AUTRE.Degats"}} / {{localize "KNIGHT.AUTRE.Violence"}}
-                            </button>       
+                            </button>
 
                             <button class="wolfFighter" data-label="{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.FIGHTER.Label"}}" data-barrage="true">
                                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.FIGHTER.Label"}} : {{localize "KNIGHT.EFFETS.BARRAGE.Label"}}
-                            </button>                 
+                            </button>
                         </div>
                         {{/if}}
                     </h3>
@@ -408,7 +408,7 @@
                         </div>
                     </div>
                     {{/if}}
-                    
+
                     {{#if (isValue systemData.configurationActive 'tech')}}
                     <div class="configuration">
                         <h6>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.TECH.Label"}}</h6>
@@ -478,7 +478,7 @@
                 </div>
 
                 <div class="liste">
-                    <h3 class="header">
+                    <h3 class="header js-toggler">
                         <i class="far fa-plus-square"></i>
                         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.Disponible"}}
                     </h3>
@@ -516,7 +516,7 @@
                         </div>
                     </div>
                     {{/unless}}
-                    
+
                     {{#unless (isValue systemData.configurationActive 'tech')}}
                     <div class="configuration" style="display:none;">
                         <h6>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.TECH.Label"}}</h6>
@@ -589,7 +589,7 @@
 
             {{#if systemData.options.jetsSpeciaux}}
             <div class="jetsSpeciaux">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.ITEMS.MODULE.PNJ.JETSPECIAL.Label"}}
                 </h2>
@@ -605,17 +605,17 @@
 
             {{#unless systemData.options.noCapacites}}
             <div class="capacite">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.CAPACITES.Label"}}
 
                     <a class="item-control item-create" title="Create Item" data-type="capacite"><i class="fas fa-plus"></i></a>
                 </h2>
-                
+
                 {{#each actor.capacites as | key module|}}
                 <div class="bCapacite">
-                    <header class="summary header" data-item-id="{{key._id}}">
-                        <i class="far fa-plus-square extendButton"></i>                        
+                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
+                        <i class="far fa-plus-square extendButton"></i>
 
                         <div class="gestionButton">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -653,7 +653,7 @@
                             {{/if}}
                         </div>
                     </header>
-                    
+
                     <img class="profile-img" style="display:none;" src="{{key.img}}" title="{{key.name}}" />
                     <span class="description" style="display:none;">{{{key.system.description}}}</span>
 
@@ -773,7 +773,7 @@
                                 </div>
                             </div>
                             {{/if}}
- 
+
                         </div>
                     </div>
                 </div>
@@ -783,7 +783,7 @@
 
             {{#if systemData.options.modules}}
             <div class="modules">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.ITEMS.MODULE.Label"}}
 
@@ -792,8 +792,8 @@
 
                 {{#each actor.modules as | key module|}}
                 <div class="bModule">
-                    <header class="summary header" data-item-id="{{key._id}}">
-                        <i class="far fa-plus-square extendButton"></i>                        
+                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
+                        <i class="far fa-plus-square extendButton"></i>
 
                         <div class="gestionButton">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -841,7 +841,7 @@
                                         {{localize "KNIGHT.ITEMS.MODULE.DepenseSupplementaire"}}
                                     </button>
                                 {{/if}}
-                            {{/if}}                                            
+                            {{/if}}
                             {{#unless key.system.active.pnj}}
                                 {{#each key.system.pnj.liste as | keyPnj pnj|}}
                                     {{#if (isHigherThan key.system.energie.tour.value 0)}}
@@ -852,7 +852,7 @@
                                             </button>
                                         {{/unless}}
                                     {{/if}}
-                                    
+
                                     {{#if (isHigherThan key.system.energie.minute.value 0)}}
                                         {{#unless key.system.active.pnj}}
                                             <button class="activation" data-type="modulePnj" data-module="{{key._id}}"
@@ -877,7 +877,7 @@
                             {{/if}}
                         </div>
                     </header>
-                    
+
                     <img class="profile-img" style="display:none;" src="{{key.img}}" title="{{key.name}}" />
                     <span class="description" style="display:none;">{{{key.system.description}}}</span>
 
@@ -925,7 +925,7 @@
                                 <span class="textarea">{{{capaciteDescription key.system.duree}}}</span>
                                 {{/if}}
                             </div>
-                            
+
                             {{#if key.system.bonus.has}}
                             <div class="data">
                                 <h4 class="title">{{localize "KNIGHT.BONUS.Label"}}</h4>
@@ -1010,7 +1010,7 @@
                                     <span class="header">{{localize "KNIGHT.PORTEE.Label"}}</span>
                                     <span class="score">{{getPortee key.system.arme.portee}}</span>
                                 </div>
-                                
+
                                 <h4 class="separation">{{localize "KNIGHT.AUTRE.Degats"}}</h4>
                                 {{#unless key.system.arme.degats.variable.has}}
                                 <div class="middlespan noSeparation">
@@ -1027,7 +1027,7 @@
                                     <span class="score">{{key.system.arme.degats.variable.max.dice}}{{localize "KNIGHT.JETS.Des-short"}}6+{{key.system.arme.degats.variable.max.fixe}}</span>
                                 </div>
                                 {{/unless}}
-                                
+
                                 <h4 class="separation">{{localize "KNIGHT.AUTRE.Violence"}}</h4>
                                 {{#unless key.system.arme.violence.variable.has}}
                                 <div class="middlespan noSeparation">
@@ -1199,14 +1199,14 @@
             {{/if}}
 
             <div class="aspectsexceptionnels">
-                <h2 class="header">
+                <h2 class="header js-toggler">
                     <i class="far fa-minus-square"></i>
                     {{localize "KNIGHT.ASPECTS.Exceptionnels"}}
                 </h2>
 
                 {{#each actor.aspectexceptionnel as | key aspect|}}
                 <div class="data">
-                    <h3 class="header">
+                    <h3 class="header js-toggler">
                         <i class="far fa-plus-square"></i>
 
                         {{getAspect aspect}}
@@ -1241,7 +1241,7 @@
                         {{/each}}
                     </div>
                 </div>
-                
+
                 <div class="armesDistance">
                     <div class="block">
                         <h2 class="header">
@@ -1259,13 +1259,13 @@
             {{#unless systemData.options.noArmesImprovisees}}
             <div class="main">
                 <div class="armesImprovisees">
-                    <h2 class="header">
+                    <h2 class="header js-toggler">
                         <i class="far fa-plus-square"></i>
                         {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.LabelContact"}}
                     </h2>
                     {{#each systemData.combat.armesimprovisees.liste as | kAI armesimprovisees|}}
                         <div class="block">
-                            <h3 class="header">
+                            <h3 class="header js-toggler">
                                 <i class="far fa-plus-square"></i>
                                 {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.Chair"}} : {{#each kAI.chair as | kChair chair|}} {{#unless @first}}/{{/unless}} {{kChair}}{{/each}}
                             </h3>
@@ -1284,10 +1284,10 @@
                                             <span>{{key.violence.dice}}{{localize "KNIGHT.JETS.Des-short"}}6</span>
                                         </div>
 
-                                        <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn" 
+                                        <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn"
                                         data-id="contact"
-                                        data-name="{{armesimprovisees}}" 
-                                        data-isDistance="armesimprovisees" 
+                                        data-name="{{armesimprovisees}}"
+                                        data-isDistance="armesimprovisees"
                                         data-num="{{arme}}" data-aspect="{{@root/systemData/combat/armesimprovisees/aspect}}" />
                                     </div>
                                 </div>
@@ -1302,7 +1302,7 @@
                     </h2>
                     {{#each systemData.combat.armesimprovisees.liste as | kAI armesimprovisees|}}
                         <div class="block">
-                            <h3 class="header">
+                            <h3 class="header js-toggler">
                                 <i class="far fa-plus-square"></i>
                                 {{localize "KNIGHT.COMBAT.ARMESIMPROVISEES.Chair"}} : {{#each kAI.chair as | kChair chair|}} {{#unless @first}}/{{/unless}} {{kChair}}{{/each}}
                             </h3>
@@ -1321,9 +1321,9 @@
                                             <span>{{key.violence.dice}}{{localize "KNIGHT.JETS.Des-short"}}6</span>
                                         </div>
 
-                                        <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn" 
-                                        data-id="distance" 
-                                        data-name="{{armesimprovisees}}" 
+                                        <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn"
+                                        data-id="distance"
+                                        data-name="{{armesimprovisees}}"
                                         data-isDistance="armesimprovisees" data-num="{{arme}}"
                                         data-aspect="{{@root/systemData/combat/armesimprovisees/aspect}}" />
                                     </div>
@@ -1359,7 +1359,7 @@
                             </div>
                             {{/each}}
                         </div>
-                        
+
                         <div class="blockRoll">
                             <img src="systems/knight/assets/icons/D6Black.svg" class="dice jetWpn" data-name="{{grenades}}" data-id="" data-isDistance="grenades" data-num="" />
                         </div>
@@ -1381,7 +1381,7 @@
                             {{/each}}
                         </div>
                     </div>
-                    
+
                     {{#unless systemData.options.noNods}}
                     <div class="nods">
                         <h2 class="header">
@@ -1397,9 +1397,9 @@
                                 <input type="number" name="system.combat.nods.{{nods}}.max" value="{{key.max}}" />
                             </div>
                             <div class="blockRoll">
-                                <img src="systems/knight/assets/icons/D6Black.svg" title='{{localize "KNIGHT.COMBAT.NODS.SoiMeme"}}' class="dice" 
+                                <img src="systems/knight/assets/icons/D6Black.svg" title='{{localize "KNIGHT.COMBAT.NODS.SoiMeme"}}' class="dice"
                                     data-nods="{{nods}}" data-number="{{key.value}}" />
-                                <img src="systems/knight/assets/icons/D6TargetBlack.svg" title='{{localize "KNIGHT.COMBAT.NODS.Autrui"}}' class="diceTarget" 
+                                <img src="systems/knight/assets/icons/D6TargetBlack.svg" title='{{localize "KNIGHT.COMBAT.NODS.Autrui"}}' class="diceTarget"
                                     data-nods="{{nods}}" data-number="{{key.value}}" />
                             </div>
                         </div>
@@ -1561,11 +1561,11 @@
                                     <option value="{{key}}">{{localize "KNIGHT.AUTRE.Majeur"}} ({{key}})</option>
                                 {{/each}}
                             {{/select}}
-                        </select>                        
+                        </select>
                     </div>
                     {{/each}}
                 </div>
-                
+
             </div>
             {{/if}}
         </div>

--- a/templates/actors/special/apeiron.html
+++ b/templates/actors/special/apeiron.html
@@ -1,6 +1,6 @@
 
 <div class="apeiron">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.APEIRON.Label"}}
     </h3>

--- a/templates/actors/special/contrecoups.html
+++ b/templates/actors/special/contrecoups.html
@@ -1,6 +1,6 @@
 
 <div class="contrecoups">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.CONTRECOUPS.Label"}}
 
@@ -28,11 +28,11 @@
             <span class="button noBorderTop {{#if this.relance.value}}selected{{/if}}">{{this.relance.label}}</span>
 
             <span class="button {{#if this.maxeffets.value}}selected borderBottom{{/if}}">{{this.maxeffets.label}}</span>
-        
+
             <div class="longspan {{#unless this.maxeffets.value}}hidden{{/unless}}">
                 <span class="header">{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.CONTRECOUPS.MaxEffetsLabel"}}</span>
                 <span class="score">{{this.maxeffets.max}}</span>
-            </div>                
+            </div>
         </div>
 
         <div class="data">

--- a/templates/actors/special/impregnation.html
+++ b/templates/actors/special/impregnation.html
@@ -1,6 +1,6 @@
 
 <div class="impregnation">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.IMPREGNATION.Label"}}
 

--- a/templates/actors/special/lenteetlourde.html
+++ b/templates/actors/special/lenteetlourde.html
@@ -1,5 +1,5 @@
 <div class="lenteetlourde">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.LENTEETLOURDE.Label"}}
     </h3>

--- a/templates/actors/special/personnalise.html
+++ b/templates/actors/special/personnalise.html
@@ -1,5 +1,5 @@
 <div class="personnalise">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PERSONNALISE.Label"}}
     </h3>

--- a/templates/actors/special/plusespoir.html
+++ b/templates/actors/special/plusespoir.html
@@ -1,5 +1,5 @@
 <div class="plusespoir">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PLUSESPOIR.Label"}}
     </h3>

--- a/templates/actors/special/porteurlumiere.html
+++ b/templates/actors/special/porteurlumiere.html
@@ -1,6 +1,6 @@
 
 <div class="porteurlumiere">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PORTEURLUMIERE.Label"}}
     </h3>

--- a/templates/actors/special/recolteflux.html
+++ b/templates/actors/special/recolteflux.html
@@ -1,5 +1,5 @@
 <div class="recolteflux">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.Label"}}
 
@@ -35,7 +35,7 @@
                 {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.PatronTue"}}
             </button>
         </div>
-        {{/if}}        
+        {{/if}}
     </h3>
 
     <span class="description" style="display:none">{{{this.description}}}</span>

--- a/templates/actors/specialLegende/recolteflux.html
+++ b/templates/actors/specialLegende/recolteflux.html
@@ -1,5 +1,5 @@
 <div class="recolteflux">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-plus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.Label"}}
 
@@ -35,7 +35,7 @@
                 {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.PatronTue"}}
             </button>
         </div>
-        {{/if}}        
+        {{/if}}
     </h3>
 
     <span class="description" style="display:none">{{{this.description}}}</span>

--- a/templates/actors/subtab/armes.html
+++ b/templates/actors/subtab/armes.html
@@ -1,5 +1,5 @@
 <div class="wpn">
-    <header class="summary header"  data-item-id="{{this._id}}">
+    <header class="summary header js-toggler" data-item-id="{{this._id}}">
         <i class="far fa-plus-square extendButton"></i>
         {{#unless this.system.noRack}}
             <div class="gestionButton {{#if this.system.rack}}large{{/if}}">
@@ -52,9 +52,9 @@
                 <img src="systems/knight/assets/icons/D6Black.svg" class="jetWpn dice" data-name="{{this.name}}" data-id="{{this._id}}" data-isDistance="{{#if this.system.tourelle.has}}tourelle{{else}}{{this.system.type}}{{/if}}" data-num="{{num}}" />
             {{/if}}
         </div>
-        
+
     </header>
-    
+
     <div class="effets" style="display:none;">
         <div class="blockEffets">
             {{#each this.system.effets.liste as | key effet|}}

--- a/templates/actors/vehicule-sheet.html
+++ b/templates/actors/vehicule-sheet.html
@@ -67,7 +67,6 @@
                 </div>
             </div>
         </section>
-
         <section class="mainBlock">
             <div class="armure">
                 <div class="line">
@@ -164,7 +163,7 @@
 
                 {{#each actor.modules as | key module|}}
                 <div class="bModule">
-                    <header class="summary header" data-item-id="{{key._id}}">
+                    <header class="summary header js-toggler" data-item-id="{{key._id}}">
                         <i class="far fa-plus-square extendButton"></i>
 
                         <div class="gestionButton">
@@ -634,7 +633,7 @@
 
                         {{#each actor.armesDistance as | key arme|}}
                             <div class="wpn">
-                                <header class="summary header"  data-item-id="{{this._id}}">
+                                <header class="summary header js-toggler" data-item-id="{{this._id}}">
                                     <i class="far fa-plus-square extendButton"></i>
                                     <div class="gestionButton">
                                         <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>

--- a/templates/items/arme-sheet.html
+++ b/templates/items/arme-sheet.html
@@ -21,7 +21,7 @@
             </select>
         </label>
     </div>
-    
+
     <header class="sheet-header flexrow">
         <h1 class="charname">
             <input name="name" type="text" value="{{data.name}}" placeholder="{{localize "KNIGHT.Nom"}}" />
@@ -54,7 +54,7 @@
                 <option value="lointaine">{{localize "KNIGHT.PORTEE.Lointaine"}}</option>
                 {{/select}}
             </select>
-        </label>      
+        </label>
 
         <label>
             <span class="header">{{localize "KNIGHT.AUTRE.Degats"}}</span>
@@ -99,7 +99,7 @@
     </header>
 
     <div class="blockEffets">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.EFFETS.Label"}}
         </h2>
@@ -120,11 +120,11 @@
 
     {{#unless (isWpnDistance systemData.type)}}
     <div class="blockEffets">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.AMELIORATIONS.LABEL.Structurelles"}}
         </h2>
-        
+
         <div class="structurelles">
             {{#each systemData.structurelles.liste as | key effet|}}
                 <div>
@@ -140,11 +140,11 @@
     </div>
 
     <div class="blockEffets">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.AMELIORATIONS.LABEL.Ornementales"}}
         </h2>
-        
+
         <div class="ornementales">
             {{#each systemData.ornementales.liste as | key effet|}}
                 <div>
@@ -162,11 +162,11 @@
 
     {{#if (isWpnDistance systemData.type)}}
     <div class="blockEffets">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.AMELIORATIONS.LABEL.Distance"}}
         </h2>
-        
+
         <div class="distance">
             {{#each systemData.distance.liste as | key effet|}}
                 <div>

--- a/templates/items/armure-sheet.html
+++ b/templates/items/armure-sheet.html
@@ -74,7 +74,7 @@
     </header>
 
     <div class="description">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.Description"}}
         </h2>
@@ -83,7 +83,7 @@
     </div>
 
     <div class="capacites">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.CAPACITES.Label"}}
         </h2>
@@ -104,7 +104,7 @@
     </div>
 
     <div class="special">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.ARMURE.Special"}}
         </h2>
@@ -125,7 +125,7 @@
     </div>
 
     <div class="slots">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.ARMURE.SLOTS.Label"}}
         </h2>
@@ -164,7 +164,7 @@
     </div>
 
     <div class="overdrives">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.ARMURE.Overdrives"}}
         </h2>
@@ -199,7 +199,7 @@
         {{systemData.evolutions.aAcheter.label}}</button>
         {{#each systemData.evolutions.liste as | key evolution|}}
         <div class="liste">
-            <h2 class="header">
+            <h2 class="header js-toggler">
                 <i class="far fa-minus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.EVOLUTIONS.Label"}}
 

--- a/templates/items/armurelegende-sheet.html
+++ b/templates/items/armurelegende-sheet.html
@@ -6,7 +6,7 @@
     </header>
 
     <div class="capacites">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.CAPACITES.Label"}}
         </h2>
@@ -15,7 +15,7 @@
             <select name="system.capacites.actuel">
                 {{#select systemData.capacites.actuel}}
                 <option value=""></option>
-                    {{#each systemData.capacites.liste  as | key capacite|}} 
+                    {{#each systemData.capacites.liste  as | key capacite|}}
                         <option value="{{key.key}}">{{key.label}}</option>
                     {{/each}}
                 {{/select}}
@@ -27,7 +27,7 @@
     </div>
 
     <div class="special">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.ARMURE.Special"}}
         </h2>

--- a/templates/items/armures/capacites/ascension.html
+++ b/templates/items/armures/capacites/ascension.html
@@ -1,6 +1,6 @@
 
 <div class="ascension">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ASCENSION.Label"}}
         <div>
@@ -25,24 +25,24 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.AUTRE.Minimum"}}</span>
-                <input type="number" name="system.capacites.selected.ascension.energie.min" 
-                value="{{this.energie.min}}" 
+                <input type="number" name="system.capacites.selected.ascension.energie.min"
+                value="{{this.energie.min}}"
                 min="0"
                 max="{{this.energie.max}}"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.AUTRE.Maximum"}}</span>
-                <input type="number" name="system.capacites.selected.ascension.energie.max" 
-                value="{{this.energie.max}}" 
+                <input type="number" name="system.capacites.selected.ascension.energie.max"
+                value="{{this.energie.max}}"
                 min="0"
                 max="{{this.energie.limite}}"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan separation">
                 <span>{{localize "KNIGHT.AUTRE.GainImpregnation"}}</span>
-                <input type="number" name="system.capacites.selected.ascension.impregnation" 
-                value="{{this.impregnation}}" 
+                <input type="number" name="system.capacites.selected.ascension.impregnation"
+                value="{{this.impregnation}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>

--- a/templates/items/armures/capacites/borealis.html
+++ b/templates/items/armures/capacites/borealis.html
@@ -1,6 +1,6 @@
 
 <div class="borealis">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.Label"}}
         <div>
@@ -27,13 +27,13 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.SUPPORT.Base"}}</span>
-                <input type="number" name="system.capacites.selected.borealis.support.energie.base" value="{{this.support.energie.base}}" 
+                <input type="number" name="system.capacites.selected.borealis.support.energie.base" value="{{this.support.energie.base}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.SUPPORT.Allie"}}</span>
-                <input type="number" name="system.capacites.selected.borealis.support.energie.allie" value="{{this.support.energie.allie}}" 
+                <input type="number" name="system.capacites.selected.borealis.support.energie.allie" value="{{this.support.energie.allie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -60,7 +60,7 @@
             <textarea data-capacite="borealis" data-type="descriptionOffensif" data-min="85" style="height:{{this.textarea.descriptionOffensif}}px;" name="system.capacites.selected.borealis.offensif.description" {{#if this.softlock}}disabled{{/if}}>{{this.offensif.description}}</textarea>
             <label class="longspan simpleSeparation">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.borealis.offensif.energie" value="{{this.offensif.energie}}" 
+                <input type="number" name="system.capacites.selected.borealis.offensif.energie" value="{{this.offensif.energie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -68,22 +68,22 @@
                 <div class="doubleLine">
                     <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
                     <label>
-                        <input type="number" name="system.capacites.selected.borealis.offensif.degats.dice" value="{{this.offensif.degats.dice}}" 
+                        <input type="number" name="system.capacites.selected.borealis.offensif.degats.dice" value="{{this.offensif.degats.dice}}"
                         {{#if this.softlock}}disabled{{/if}}
                         />
                         <span>{{localize "KNIGHT.JETS.Des-short"}}6</span>
-                    </label>                
+                    </label>
                 </div>
                 <div class="doubleLine">
                     <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
                     <label>
-                        <input type="number" name="system.capacites.selected.borealis.offensif.violence.dice" value="{{this.offensif.violence.dice}}" 
+                        <input type="number" name="system.capacites.selected.borealis.offensif.violence.dice" value="{{this.offensif.violence.dice}}"
                         {{#if this.softlock}}disabled{{/if}}
                         />
                         <span>{{localize "KNIGHT.JETS.Des-short"}}6</span>
-                    </label>                
+                    </label>
                 </div>
-            </div>            
+            </div>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.ACTIVATION.Label"}}</span>
                 <select name="system.capacites.selected.borealis.offensif.activation" {{#if this.softlock}}disabled{{/if}}>
@@ -131,7 +131,7 @@
             <textarea data-capacite="borealis" data-type="descriptionUtilitaire" data-min="150" style="height:{{this.textarea.descriptionUtilitaire}}px;" name="system.capacites.selected.borealis.utilitaire.description" {{#if this.softlock}}disabled{{/if}}>{{this.utilitaire.description}}</textarea>
             <label class="longspan simpleSeparation">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.borealis.utilitaire.energie" value="{{this.utilitaire.energie}}" 
+                <input type="number" name="system.capacites.selected.borealis.utilitaire.energie" value="{{this.utilitaire.energie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armures/capacites/cea.html
+++ b/templates/items/armures/capacites/cea.html
@@ -1,5 +1,5 @@
 <div class="cea">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.Label"}}
         <div>
@@ -24,8 +24,8 @@
             <div class="data">
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                    <input type="number" name="system.capacites.selected.cea.energie" 
-                    value="{{this.energie}}" 
+                    <input type="number" name="system.capacites.selected.cea.energie"
+                    value="{{this.energie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -43,14 +43,14 @@
                 </label>
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                    <textarea name="system.capacites.selected.cea.duree" 
-                    data-capacite="cea" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                    <textarea name="system.capacites.selected.cea.duree"
+                    data-capacite="cea" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
                 </label>
                 <label class="longspan separation">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.Espoir"}}</span>
-                    <input type="number" name="system.capacites.selected.cea.espoir" 
-                    value="{{this.espoir}}" 
+                    <input type="number" name="system.capacites.selected.cea.espoir"
+                    value="{{this.espoir}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -59,14 +59,14 @@
             <div class="data">
                 <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.SALVE.Label"}}</h4>
                 <textarea name="system.capacites.selected.cea.salve.description"
-                data-capacite="cea" data-type="descriptionSalve" data-min="70" style="height:{{this.textarea.descriptionSalve}}px;" 
+                data-capacite="cea" data-type="descriptionSalve" data-min="70" style="height:{{this.textarea.descriptionSalve}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.salve.description}}</textarea>
                 <div class="line">
                     <div class="doubleLine">
                         <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
                         <label>
-                            <input type="number" name="system.capacites.selected.cea.salve.degats.dice" 
-                            value="{{this.salve.degats.dice}}" 
+                            <input type="number" name="system.capacites.selected.cea.salve.degats.dice"
+                            value="{{this.salve.degats.dice}}"
                             min="0"
                             {{#if this.softlock}}disabled{{/if}} />
                             <span class="{{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
@@ -76,8 +76,8 @@
                     <div class="doubleLine">
                         <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
                         <label>
-                            <input type="number" name="system.capacites.selected.cea.salve.violence.dice" 
-                            value="{{this.salve.violence.dice}}" 
+                            <input type="number" name="system.capacites.selected.cea.salve.violence.dice"
+                            value="{{this.salve.violence.dice}}"
                             min="0"
                             {{#if this.softlock}}disabled{{/if}} />
                             <span class="{{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
@@ -86,8 +86,8 @@
                 </div>
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-                    <textarea name="system.capacites.selected.cea.salve.portee" 
-                        data-capacite="cea" data-type="porteeSalve" data-min="50" style="height:{{this.textarea.porteeSalve}}px;" 
+                    <textarea name="system.capacites.selected.cea.salve.portee"
+                        data-capacite="cea" data-type="porteeSalve" data-min="50" style="height:{{this.textarea.porteeSalve}}px;"
                         {{#if this.softlock}}disabled{{/if}}>{{this.salve.portee}}</textarea>
                 </label>
                 <div class="effets">
@@ -104,19 +104,19 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="col">
             <div class="data">
                 <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.VAGUE.Label"}}</h4>
                 <textarea name="system.capacites.selected.cea.vague.description"
-                data-capacite="cea" data-type="descriptionVague" data-min="70" style="height:{{this.textarea.descriptionVague}}px;" 
+                data-capacite="cea" data-type="descriptionVague" data-min="70" style="height:{{this.textarea.descriptionVague}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.vague.description}}</textarea>
                 <div class="line">
                     <div class="doubleLine">
                         <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
                         <label>
-                            <input type="number" name="system.capacites.selected.cea.vague.degats.dice" 
-                            value="{{this.vague.degats.dice}}" 
+                            <input type="number" name="system.capacites.selected.cea.vague.degats.dice"
+                            value="{{this.vague.degats.dice}}"
                             min="0"
                             {{#if this.softlock}}disabled{{/if}} />
                             <span class="{{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
@@ -126,8 +126,8 @@
                     <div class="doubleLine">
                         <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
                         <label>
-                            <input type="number" name="system.capacites.selected.cea.vague.violence" 
-                            value="{{this.vague.violence.dice}}" 
+                            <input type="number" name="system.capacites.selected.cea.vague.violence"
+                            value="{{this.vague.violence.dice}}"
                             min="0"
                             {{#if this.softlock}}disabled{{/if}} />
                             <span class="{{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
@@ -136,8 +136,8 @@
                 </div>
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-                    <textarea name="system.capacites.selected.cea.vague.portee" 
-                        data-capacite="cea" data-type="porteeVague" data-min="50" style="height:{{this.textarea.porteeVague}}px;" 
+                    <textarea name="system.capacites.selected.cea.vague.portee"
+                        data-capacite="cea" data-type="porteeVague" data-min="50" style="height:{{this.textarea.porteeVague}}px;"
                         {{#if this.softlock}}disabled{{/if}}>{{this.vague.portee}}</textarea>
                 </label>
                 <div class="effets">
@@ -157,14 +157,14 @@
             <div class="data">
                 <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.RAYON.Label"}}</h4>
                 <textarea name="system.capacites.selected.cea.rayon.description"
-                data-capacite="cea" data-type="descriptionRayon" data-min="150" style="height:{{this.textarea.descriptionRayon}}px;" 
+                data-capacite="cea" data-type="descriptionRayon" data-min="150" style="height:{{this.textarea.descriptionRayon}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.rayon.description}}</textarea>
                 <div class="line">
                     <div class="doubleLine">
                         <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
                         <label>
-                            <input type="number" name="system.capacites.selected.cea.rayon.degats.dice" 
-                            value="{{this.rayon.degats.dice}}" 
+                            <input type="number" name="system.capacites.selected.cea.rayon.degats.dice"
+                            value="{{this.rayon.degats.dice}}"
                             min="0"
                             {{#if this.softlock}}disabled{{/if}} />
                             <span class="{{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
@@ -174,8 +174,8 @@
                     <div class="doubleLine">
                         <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
                         <label>
-                            <input type="number" name="system.capacites.selected.cea.rayon.violence" 
-                            value="{{this.rayon.violence.dice}}" 
+                            <input type="number" name="system.capacites.selected.cea.rayon.violence"
+                            value="{{this.rayon.violence.dice}}"
                             min="0"
                             {{#if this.softlock}}disabled{{/if}} />
                             <span class="{{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
@@ -184,8 +184,8 @@
                 </div>
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-                    <textarea name="system.capacites.selected.cea.rayon.portee" 
-                        data-capacite="cea" data-type="porteeRayon" data-min="50" style="height:{{this.textarea.porteeRayon}}px;" 
+                    <textarea name="system.capacites.selected.cea.rayon.portee"
+                        data-capacite="cea" data-type="porteeRayon" data-min="50" style="height:{{this.textarea.porteeRayon}}px;"
                         {{#if this.softlock}}disabled{{/if}}>{{this.rayon.portee}}</textarea>
                 </label>
                 <div class="effets">

--- a/templates/items/armures/capacites/changeling.html
+++ b/templates/items/armures/capacites/changeling.html
@@ -1,5 +1,5 @@
 <div class="changeling">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.Label"}}
         <div>
@@ -24,29 +24,29 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.Personnelle"}}</span>
-                <input type="number" name="system.capacites.selected.changeling.energie.personnel" 
-                value="{{this.energie.personnel}}" 
+                <input type="number" name="system.capacites.selected.changeling.energie.personnel"
+                value="{{this.energie.personnel}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.Etendue"}}</span>
-                <input type="number" name="system.capacites.selected.changeling.energie.etendue" 
-                value="{{this.energie.etendue}}" 
+                <input type="number" name="system.capacites.selected.changeling.energie.etendue"
+                value="{{this.energie.etendue}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.ParFauxEtres"}}</span>
-                <input type="number" name="system.capacites.selected.changeling.energie.fauxEtre.value" 
-                value="{{this.energie.fauxEtre.value}}" 
+                <input type="number" name="system.capacites.selected.changeling.energie.fauxEtre.value"
+                value="{{this.energie.fauxEtre.value}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan separation">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.FauxEtresMax"}}</span>
-                <input type="number" name="system.capacites.selected.changeling.energie.fauxEtre.max" 
-                value="{{this.energie.fauxEtre.max}}" 
+                <input type="number" name="system.capacites.selected.changeling.energie.fauxEtre.max"
+                value="{{this.energie.fauxEtre.max}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -66,14 +66,14 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.changeling.duree" 
-                data-capacite="changeling" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.changeling.duree"
+                data-capacite="changeling" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-                <textarea name="system.capacites.selected.changeling.portee" 
-                    data-capacite="changeling" data-type="portee" data-min="50" style="height:{{this.textarea.portee}}px;" 
+                <textarea name="system.capacites.selected.changeling.portee"
+                    data-capacite="changeling" data-type="portee" data-min="50" style="height:{{this.textarea.portee}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.portee}}</textarea>
             </label>
         </div>
@@ -98,29 +98,29 @@
             <label class="shortspan double {{#unless this.desactivationexplosive.acces}}hidden{{/unless}}">
                <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
                <div>
-                    <input type="number" name="system.capacites.selected.changeling.desactivationexplosive.degats.dice" 
-                    value="{{this.desactivationexplosive.degats.dice}}" 
+                    <input type="number" name="system.capacites.selected.changeling.desactivationexplosive.degats.dice"
+                    value="{{this.desactivationexplosive.degats.dice}}"
                     min="0"
-                    {{#if this.softlock}}disabled{{/if}} />                    
+                    {{#if this.softlock}}disabled{{/if}} />
                     <span class="{{localize "KNIGHT.JETS.Des-short"}}6 {{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.changeling.desactivationexplosive.degats.fixe" 
-                    value="{{this.desactivationexplosive.degats.fixe}}" 
+                    <input type="number" name="system.capacites.selected.changeling.desactivationexplosive.degats.fixe"
+                    value="{{this.desactivationexplosive.degats.fixe}}"
                     min="0"
-                    {{#if this.softlock}}disabled{{/if}} />    
+                    {{#if this.softlock}}disabled{{/if}} />
                 </div>
             </label>
             <label class="shortspan double {{#unless this.desactivationexplosive.acces}}hidden{{/unless}}">
                <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
                <div>
-                    <input type="number" name="system.capacites.selected.changeling.desactivationexplosive.violence.dice" 
-                    value="{{this.desactivationexplosive.violence.dice}}" 
+                    <input type="number" name="system.capacites.selected.changeling.desactivationexplosive.violence.dice"
+                    value="{{this.desactivationexplosive.violence.dice}}"
                     min="0"
-                    {{#if this.softlock}}disabled{{/if}} />                    
+                    {{#if this.softlock}}disabled{{/if}} />
                     <span class="{{localize "KNIGHT.JETS.Des-short"}}6 {{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.changeling.desactivationexplosive.violence.fixe" 
-                    value="{{this.desactivationexplosive.violence.fixe}}" 
+                    <input type="number" name="system.capacites.selected.changeling.desactivationexplosive.violence.fixe"
+                    value="{{this.desactivationexplosive.violence.fixe}}"
                     min="0"
-                    {{#if this.softlock}}disabled{{/if}} />    
+                    {{#if this.softlock}}disabled{{/if}} />
                 </div>
             </label>
             <div class="{{#unless this.desactivationexplosive.acces}}hidden {{else}} effets {{/unless}}">

--- a/templates/items/armures/capacites/companions.html
+++ b/templates/items/armures/capacites/companions.html
@@ -1,5 +1,5 @@
 <div class="companions">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Label"}}
         <div>
@@ -24,15 +24,15 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.ENERGIE.Base"}}</span>
-                <input type="number" name="system.capacites.selected.companions.energie.base" 
-                value="{{this.energie.base}}" 
+                <input type="number" name="system.capacites.selected.companions.energie.base"
+                value="{{this.energie.base}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.ENERGIE.Prolonger"}}</span>
-                <input type="number" name="system.capacites.selected.companions.energie.prolonger" 
-                value="{{this.energie.prolonger}}" 
+                <input type="number" name="system.capacites.selected.companions.energie.prolonger"
+                value="{{this.energie.prolonger}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -57,15 +57,15 @@
             <h4>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.Label"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.Pointgloiredepart"}}</span>
-                <input type="number" name="system.capacites.selected.companions.lion.PG" 
-                value="{{this.lion.PG}}" 
+                <input type="number" name="system.capacites.selected.companions.lion.PG"
+                value="{{this.lion.PG}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
         </div>
 
         <div class="lion">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.Label"}}
             </h4>
@@ -75,8 +75,8 @@
                         <h5>{{getAspect aspect}}</h5>
                         <label>
                             <span>{{localize "KNIGHT.ASPECTS.Aspect"}}</span>
-                            <input type="number" name="system.capacites.selected.companions.lion.aspects.{{aspect}}.value" 
-                            value="{{key.value}}" 
+                            <input type="number" name="system.capacites.selected.companions.lion.aspects.{{aspect}}.value"
+                            value="{{key.value}}"
                             min="0"
                             {{#if ../this.softlock}}disabled{{/if}} />
                         </label>
@@ -104,43 +104,43 @@
             <div class="derives" style="display:none;">
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Defense"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.lion.defense.base" 
-                    value="{{this.lion.defense.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.lion.defense.base"
+                    value="{{this.lion.defense.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Reaction"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.lion.reaction.base" 
-                    value="{{this.lion.reaction.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.lion.reaction.base"
+                    value="{{this.lion.reaction.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
                     <div class="block">
-                        <input type="number" name="system.capacites.selected.companions.lion.initiative.value" 
-                        value="{{this.lion.initiative.value}}" 
+                        <input type="number" name="system.capacites.selected.companions.lion.initiative.value"
+                        value="{{this.lion.initiative.value}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                        <input type="number" name="system.capacites.selected.companions.lion.initiative.fixe" 
+                        <input type="number" name="system.capacites.selected.companions.lion.initiative.fixe"
                         value="{{this.lion.initiative.fixe}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
-                    </div>                    
+                    </div>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Armure"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.lion.armure.base" 
-                    value="{{this.lion.armure.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.lion.armure.base"
+                    value="{{this.lion.armure.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.ChampDeForce"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.lion.champDeForce.base" 
-                    value="{{this.lion.champDeForce.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.lion.champDeForce.base"
+                    value="{{this.lion.champDeForce.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
@@ -156,7 +156,7 @@
                 {{#each this.lion.armes.contact as | key arme|}}
                     <div class="line {{#unless @first}} separation {{/unless}}">
                         <div class="label">
-                            <input type="text" name="system.capacites.selected.companions.lion.armes.contact.{{arme}}.label" value="{{key.label}}" 
+                            <input type="text" name="system.capacites.selected.companions.lion.armes.contact.{{arme}}.label" value="{{key.label}}"
                             {{#if ../this.softlock}}disabled{{/if}}
                             />
                         </div>
@@ -208,7 +208,7 @@
         </div>
 
         <div class="wolf">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.Label"}}
             </h4>
@@ -218,8 +218,8 @@
                         <h5>{{getAspect aspect}}</h5>
                         <label>
                             <span>{{localize "KNIGHT.ASPECTS.Aspect"}}</span>
-                            <input type="number" name="system.capacites.selected.companions.wolf.aspects.{{aspect}}.value" 
-                            value="{{key.value}}" 
+                            <input type="number" name="system.capacites.selected.companions.wolf.aspects.{{aspect}}.value"
+                            value="{{key.value}}"
                             min="0"
                             {{#if ../this.softlock}}disabled{{/if}} />
                         </label>
@@ -247,43 +247,43 @@
             <div class="derives" style="display:none;">
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Defense"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.wolf.defense.base" 
-                    value="{{this.wolf.defense.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.wolf.defense.base"
+                    value="{{this.wolf.defense.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Reaction"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.wolf.reaction.base" 
-                    value="{{this.wolf.reaction.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.wolf.reaction.base"
+                    value="{{this.wolf.reaction.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
                     <div class="block">
-                        <input type="number" name="system.capacites.selected.companions.wolf.initiative.value" 
-                        value="{{this.wolf.initiative.value}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.initiative.value"
+                        value="{{this.wolf.initiative.value}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.initiative.fixe" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.initiative.fixe"
                         value="{{this.wolf.initiative.fixe}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
-                    </div>                    
+                    </div>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Armure"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.wolf.armure.base" 
-                    value="{{this.wolf.armure.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.wolf.armure.base"
+                    value="{{this.wolf.armure.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.ChampDeForce"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.wolf.champDeForce.base" 
-                    value="{{this.wolf.champDeForce.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.wolf.champDeForce.base"
+                    value="{{this.wolf.champDeForce.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
@@ -299,7 +299,7 @@
                 {{#each this.wolf.armes.contact as | key arme|}}
                     <div class="line {{#unless @first}} separation {{/unless}}">
                         <div class="label">
-                            <input type="text" name="system.capacites.selected.companions.wolf.armes.contact.{{arme}}.label" value="{{key.label}}" 
+                            <input type="text" name="system.capacites.selected.companions.wolf.armes.contact.{{arme}}.label" value="{{key.label}}"
                             {{#if ../this.softlock}}disabled{{/if}}
                             />
                         </div>
@@ -357,15 +357,15 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.labor.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.labor.energie" 
-                        value="{{this.wolf.configurations.labor.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.labor.energie"
+                        value="{{this.wolf.configurations.labor.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.labor.bonus.roll" 
-                        value="{{this.wolf.configurations.labor.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.labor.bonus.roll"
+                        value="{{this.wolf.configurations.labor.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
@@ -379,29 +379,29 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.medic.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.energie" 
-                        value="{{this.wolf.configurations.medic.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.energie"
+                        value="{{this.wolf.configurations.medic.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.bonus.roll" 
-                        value="{{this.wolf.configurations.medic.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.bonus.roll"
+                        value="{{this.wolf.configurations.medic.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
                     </label>
                     <label class="longspanWSante">
                         <span class="label">{{localize "KNIGHT.BONUS.Soins"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.bonus.soins" 
-                        value="{{this.wolf.configurations.medic.bonus.soins}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.bonus.soins"
+                        value="{{this.wolf.configurations.medic.bonus.soins}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="sante">{{localize "KNIGHT.AUTRE.PointSante-short"}}</span>
                     </label>
                 </div>
-                
+
                 <div class="configuration">
                     <h6>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.TECH.Label"}}</h6>
                     <textarea data-capacite="companions" data-type="tech" data-min="50" style="height:{{this.textarea.tech}}px;"
@@ -409,23 +409,23 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.tech.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.energie" 
-                        value="{{this.wolf.configurations.tech.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.energie"
+                        value="{{this.wolf.configurations.tech.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.bonus.roll" 
-                        value="{{this.wolf.configurations.tech.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.bonus.roll"
+                        value="{{this.wolf.configurations.tech.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
                     </label>
                     <label class="longspanWArmure">
                         <span class="label">{{localize "KNIGHT.BONUS.Reparation"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.bonus.reparation" 
-                        value="{{this.wolf.configurations.tech.bonus.reparation}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.bonus.reparation"
+                        value="{{this.wolf.configurations.tech.bonus.reparation}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="armure">{{localize "KNIGHT.AUTRE.PointArmure-short"}}</span>
@@ -439,15 +439,15 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.recon.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.recon.energie" 
-                        value="{{this.wolf.configurations.recon.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.recon.energie"
+                        value="{{this.wolf.configurations.recon.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.recon.bonus.roll" 
-                        value="{{this.wolf.configurations.recon.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.recon.bonus.roll"
+                        value="{{this.wolf.configurations.recon.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
@@ -461,31 +461,31 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.fighter.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.energie" 
-                        value="{{this.wolf.configurations.fighter.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.energie"
+                        value="{{this.wolf.configurations.fighter.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.bonus.roll" 
-                        value="{{this.wolf.configurations.fighter.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.bonus.roll"
+                        value="{{this.wolf.configurations.fighter.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
                     </label>
                     <label class="longspanWDegats">
                         <span class="label">{{localize "KNIGHT.AUTRE.Degats"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.degats" 
-                        value="{{this.wolf.configurations.fighter.degats}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.degats"
+                        value="{{this.wolf.configurations.fighter.degats}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="degats">{{localize "KNIGHT.JETS.Des-short"}}6</span>
                     </label>
                     <label class="longspanWViolence">
                         <span class="label">{{localize "KNIGHT.AUTRE.Violence"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.violence" 
-                        value="{{this.wolf.configurations.fighter.violence}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.violence"
+                        value="{{this.wolf.configurations.fighter.violence}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="violence">{{localize "KNIGHT.JETS.Des-short"}}6</span>
@@ -508,7 +508,7 @@
         </div>
 
         <div class="crow">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.CROW.Label"}}
             </h4>
@@ -518,8 +518,8 @@
                         <h5>{{getAspect aspect}}</h5>
                         <label>
                             <span>{{localize "KNIGHT.ASPECTS.Aspect"}}</span>
-                            <input type="number" name="system.capacites.selected.companions.crow.aspects.{{aspect}}.value" 
-                            value="{{key.value}}" 
+                            <input type="number" name="system.capacites.selected.companions.crow.aspects.{{aspect}}.value"
+                            value="{{key.value}}"
                             min="0"
                             {{#if ../this.softlock}}disabled{{/if}} />
                         </label>
@@ -529,43 +529,43 @@
             <div class="derives" style="display:none;">
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Defense"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.defense.base" 
-                    value="{{this.crow.defense.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.defense.base"
+                    value="{{this.crow.defense.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Reaction"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.reaction.base" 
-                    value="{{this.crow.reaction.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.reaction.base"
+                    value="{{this.crow.reaction.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
                     <div class="block">
-                        <input type="number" name="system.capacites.selected.companions.crow.initiative.value" 
-                        value="{{this.crow.initiative.value}}" 
+                        <input type="number" name="system.capacites.selected.companions.crow.initiative.value"
+                        value="{{this.crow.initiative.value}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                        <input type="number" name="system.capacites.selected.companions.crow.initiative.fixe" 
+                        <input type="number" name="system.capacites.selected.companions.crow.initiative.fixe"
                         value="{{this.crow.initiative.fixe}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
-                    </div>                    
+                    </div>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Cohesion"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.cohesion.base" 
-                    value="{{this.crow.cohesion.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.cohesion.base"
+                    value="{{this.crow.cohesion.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.ChampDeForce"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.champDeForce.base" 
-                    value="{{this.crow.champDeForce.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.champDeForce.base"
+                    value="{{this.crow.champDeForce.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
@@ -573,8 +573,8 @@
             <div class="debordement" style="display:none;">
                 <div class="col">
                     <h5>{{localize "KNIGHT.AUTRE.Debordement"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.debordement.base" 
-                    value="{{this.crow.debordement.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.debordement.base"
+                    value="{{this.crow.debordement.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>

--- a/templates/items/armures/capacites/discord.html
+++ b/templates/items/armures/capacites/discord.html
@@ -1,6 +1,6 @@
 
 <div class="discord">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Label"}}
         <div>
@@ -25,13 +25,13 @@
             <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Tour"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-                <input type="number" name="system.capacites.selected.discord.tour.flux" value="{{this.tour.flux}}" 
+                <input type="number" name="system.capacites.selected.discord.tour.flux" value="{{this.tour.flux}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.discord.tour.energie" value="{{this.tour.energie}}" 
+                <input type="number" name="system.capacites.selected.discord.tour.energie" value="{{this.tour.energie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -56,13 +56,13 @@
             <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Scene"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-                <input type="number" name="system.capacites.selected.discord.scene.flux" value="{{this.scene.flux}}" 
+                <input type="number" name="system.capacites.selected.discord.scene.flux" value="{{this.scene.flux}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.discord.scene.energie" value="{{this.scene.energie}}" 
+                <input type="number" name="system.capacites.selected.discord.scene.energie" value="{{this.scene.energie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -86,19 +86,19 @@
         <div class="data fullWidth">
             <label class="doubleLine">
                 <span>{{localize "KNIGHT.MALUS.Actions"}}</span>
-                <input type="number" name="system.capacites.selected.discord.malus.actions" value="{{this.malus.actions}}" 
+                <input type="number" name="system.capacites.selected.discord.malus.actions" value="{{this.malus.actions}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="doubleLine">
                 <span>{{localize "KNIGHT.MALUS.Reaction"}}</span>
-                <input type="number" name="system.capacites.selected.discord.malus.reaction" value="{{this.malus.reaction}}" 
+                <input type="number" name="system.capacites.selected.discord.malus.reaction" value="{{this.malus.reaction}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="doubleLine">
                 <span>{{localize "KNIGHT.MALUS.Defense"}}</span>
-                <input type="number" name="system.capacites.selected.discord.malus.defense" value="{{this.malus.defense}}" 
+                <input type="number" name="system.capacites.selected.discord.malus.defense" value="{{this.malus.defense}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armures/capacites/falcon.html
+++ b/templates/items/armures/capacites/falcon.html
@@ -1,6 +1,6 @@
 
 <div class="falcon">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FALCON.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.falcon.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.falcon.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -42,8 +42,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.falcon.duree" 
-                data-capacite="falcon" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.falcon.duree"
+                data-capacite="falcon" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armures/capacites/forward.html
+++ b/templates/items/armures/capacites/forward.html
@@ -1,6 +1,6 @@
 
 <div class="forward">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FORWARD.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FORWARD.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.forward.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.forward.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -42,8 +42,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.forward.duree" 
-                data-capacite="forward" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.forward.duree"
+                data-capacite="forward" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armures/capacites/ghost.html
+++ b/templates/items/armures/capacites/ghost.html
@@ -1,6 +1,6 @@
 
 <div class="ghost">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.Label"}}
         <div>
@@ -25,15 +25,15 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.ENERGIE.Tour"}}</span>
-                <input type="number" name="system.capacites.selected.ghost.energie.tour" 
-                value="{{this.energie.tour}}" 
+                <input type="number" name="system.capacites.selected.ghost.energie.tour"
+                value="{{this.energie.tour}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.ENERGIE.Minute"}}</span>
-                <input type="number" name="system.capacites.selected.ghost.energie.minute" 
-                value="{{this.energie.minute}}" 
+                <input type="number" name="system.capacites.selected.ghost.energie.minute"
+                value="{{this.energie.minute}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -50,8 +50,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.ghost.duree" 
-                data-capacite="ghost" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.ghost.duree"
+                data-capacite="ghost" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
             <button type="action" class="{{#unless this.softlock}}notDisabled{{/unless}} {{#if this.interruption.actif}}selected{{/if}}"

--- a/templates/items/armures/capacites/goliath.html
+++ b/templates/items/armures/capacites/goliath.html
@@ -1,6 +1,6 @@
 
 <div class="goliath">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GOLIATH.Label"}}
         <div>

--- a/templates/items/armures/capacites/illumination.html
+++ b/templates/items/armures/capacites/illumination.html
@@ -1,6 +1,6 @@
 
 <div class="illumination">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}}
         <div>

--- a/templates/items/armures/capacites/longbow.html
+++ b/templates/items/armures/capacites/longbow.html
@@ -1,6 +1,6 @@
 
 <div class="longbow">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.Label"}}
         <div>
@@ -26,7 +26,7 @@
                 <h4>{{localize "KNIGHT.PORTEE.Label"}}</h4>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.PORTEE.Cout"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.portee.energie" value="{{this.portee.energie}}" 
+                    <input type="number" name="system.capacites.selected.longbow.portee.energie" value="{{this.portee.energie}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
@@ -58,19 +58,19 @@
                 <h4>{{localize "KNIGHT.AUTRE.Degats"}}</h4>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.DEGATS.Cout"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.degats.energie" value="{{this.degats.energie}}" 
+                    <input type="number" name="system.capacites.selected.longbow.degats.energie" value="{{this.degats.energie}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.DEGATS.Min"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.degats.min" value="{{this.degats.min}}" 
+                    <input type="number" name="system.capacites.selected.longbow.degats.min" value="{{this.degats.min}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.DEGATS.Max"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.degats.max" value="{{this.degats.max}}" 
+                    <input type="number" name="system.capacites.selected.longbow.degats.max" value="{{this.degats.max}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
@@ -80,19 +80,19 @@
                 <h4>{{localize "KNIGHT.AUTRE.Violence"}}</h4>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.VIOLENCE.Cout"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.violence.energie" value="{{this.violence.energie}}" 
+                    <input type="number" name="system.capacites.selected.longbow.violence.energie" value="{{this.violence.energie}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.VIOLENCE.Min"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.violence.min" value="{{this.violence.min}}" 
+                    <input type="number" name="system.capacites.selected.longbow.violence.min" value="{{this.violence.min}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.VIOLENCE.Max"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.violence.max" value="{{this.violence.max}}" 
+                    <input type="number" name="system.capacites.selected.longbow.violence.max" value="{{this.violence.max}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
@@ -120,7 +120,7 @@
                 <h4>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.EFFETS.Liste1"}}</h4>
                 <label class="longspan borderBottom">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.EFFETS.Cout"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.effets.liste1.energie" value="{{this.effets.liste1.energie}}" 
+                    <input type="number" name="system.capacites.selected.longbow.effets.liste1.energie" value="{{this.effets.liste1.energie}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
@@ -142,7 +142,7 @@
                 <h4>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.EFFETS.Liste2"}}</h4>
                 <label class="longspan borderBottom">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.EFFETS.Cout"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.effets.liste2.energie" value="{{this.effets.liste2.energie}}" 
+                    <input type="number" name="system.capacites.selected.longbow.effets.liste2.energie" value="{{this.effets.liste2.energie}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
@@ -169,7 +169,7 @@
                 </button>
                 <label class="longspan  borderBottom {{#unless this.effets.liste3.acces}}hidden{{/unless}}">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.EFFETS.Cout"}}</span>
-                    <input type="number" name="system.capacites.selected.longbow.effets.liste3.energie" value="{{this.effets.liste3.energie}}" 
+                    <input type="number" name="system.capacites.selected.longbow.effets.liste3.energie" value="{{this.effets.liste3.energie}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>

--- a/templates/items/armures/capacites/mechanic.html
+++ b/templates/items/armures/capacites/mechanic.html
@@ -1,6 +1,6 @@
 
 <div class="mechanic">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Label"}}
         <div>
@@ -25,7 +25,7 @@
             <h4>{{localize "KNIGHT.AUTRE.Contact"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.mechanic.energie.contact" value="{{this.energie.contact}}" 
+                <input type="number" name="system.capacites.selected.mechanic.energie.contact" value="{{this.energie.contact}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -43,19 +43,19 @@
             <div class="shortspan triple">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Reparation"}}</span>
                 <label>
-                    <input type="number" name="system.capacites.selected.mechanic.reparation.contact.dice" value="{{this.reparation.contact.dice}}" 
+                    <input type="number" name="system.capacites.selected.mechanic.reparation.contact.dice" value="{{this.reparation.contact.dice}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                     <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.mechanic.reparation.contact.fixe" value="{{this.reparation.contact.fixe}}" 
+                    <input type="number" name="system.capacites.selected.mechanic.reparation.contact.fixe" value="{{this.reparation.contact.fixe}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
             </div>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.mechanic.reparation.contact.duree" 
-                data-capacite="mechanic" data-type="dureeContact" data-min="50" style="height:{{this.textarea.dureeContact}}px;" 
+                <textarea name="system.capacites.selected.mechanic.reparation.contact.duree"
+                data-capacite="mechanic" data-type="dureeContact" data-min="50" style="height:{{this.textarea.dureeContact}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.reparation.contact.duree}}</textarea>
             </label>
         </div>
@@ -64,7 +64,7 @@
             <h4>{{localize "KNIGHT.AUTRE.Distance"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.mechanic.energie.distance" value="{{this.energie.distance}}" 
+                <input type="number" name="system.capacites.selected.mechanic.energie.distance" value="{{this.energie.distance}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -82,19 +82,19 @@
             <div class="shortspan triple">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Reparation"}}</span>
                 <label>
-                    <input type="number" name="system.capacites.selected.mechanic.reparation.distance.dice" value="{{this.reparation.distance.dice}}" 
+                    <input type="number" name="system.capacites.selected.mechanic.reparation.distance.dice" value="{{this.reparation.distance.dice}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                     <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.mechanic.reparation.distance.fixe" value="{{this.reparation.distance.fixe}}" 
+                    <input type="number" name="system.capacites.selected.mechanic.reparation.distance.fixe" value="{{this.reparation.distance.fixe}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
             </div>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.mechanic.reparation.distance.duree" 
-                data-capacite="mechanic" data-type="dureeDistance" data-min="50" style="height:{{this.textarea.dureeDistance}}px;" 
+                <textarea name="system.capacites.selected.mechanic.reparation.distance.duree"
+                data-capacite="mechanic" data-type="dureeDistance" data-min="50" style="height:{{this.textarea.dureeDistance}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.reparation.distance.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armures/capacites/morph.html
+++ b/templates/items/armures/capacites/morph.html
@@ -1,6 +1,6 @@
 
 <div class="morph">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.Label"}}
         <div>

--- a/templates/items/armures/capacites/nanoc.html
+++ b/templates/items/armures/capacites/nanoc.html
@@ -1,5 +1,5 @@
 <div class="nanoc">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.Label"}}
         <div>
@@ -24,29 +24,29 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ObjetBase"}}</span>
-                <input type="number" name="system.capacites.selected.nanoc.energie.base" 
-                value="{{this.energie.base}}" 
+                <input type="number" name="system.capacites.selected.nanoc.energie.base"
+                value="{{this.energie.base}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}}/>
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ObjetDetaille"}}</span>
-                <input type="number" name="system.capacites.selected.nanoc.energie.detaille" 
-                value="{{this.energie.detaille}}" 
+                <input type="number" name="system.capacites.selected.nanoc.energie.detaille"
+                value="{{this.energie.detaille}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}}/>
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ObjetMecanique"}}</span>
-                <input type="number" name="system.capacites.selected.nanoc.energie.mecanique" 
-                value="{{this.energie.mecanique}}" 
+                <input type="number" name="system.capacites.selected.nanoc.energie.mecanique"
+                value="{{this.energie.mecanique}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}}/>
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.AUTRE.Prolonger"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ParMinute"}}</span>
-                <input type="number" name="system.capacites.selected.nanoc.energie.prolonger" 
-                value="{{this.energie.prolonger}}" 
+                <input type="number" name="system.capacites.selected.nanoc.energie.prolonger"
+                value="{{this.energie.prolonger}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}}/>
             </label>
@@ -65,7 +65,7 @@
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                 <textarea name="system.capacites.selected.nanoc.duree"
-                data-capacite="nanoc" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                data-capacite="nanoc" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armures/capacites/oriflamme.html
+++ b/templates/items/armures/capacites/oriflamme.html
@@ -1,6 +1,6 @@
 
 <div class="oriflamme">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ORIFLAMME.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.oriflamme.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.oriflamme.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -43,8 +43,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.oriflamme.duree" 
-                data-capacite="oriflamme" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"  
+                <textarea name="system.capacites.selected.oriflamme.duree"
+                data-capacite="oriflamme" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
             <label class="shortspan">
@@ -65,13 +65,13 @@
             <div class="double">
                 <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
                 <label>
-                    <input type="number" name="system.capacites.selected.oriflamme.degats.dice" 
-                    value="{{this.degats.dice}}" 
+                    <input type="number" name="system.capacites.selected.oriflamme.degats.dice"
+                    value="{{this.degats.dice}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                     <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.oriflamme.degats.fixe" 
-                    value="{{this.degats.fixe}}" 
+                    <input type="number" name="system.capacites.selected.oriflamme.degats.fixe"
+                    value="{{this.degats.fixe}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -79,13 +79,13 @@
             <div class="double">
                 <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
                 <label>
-                    <input type="number" name="system.capacites.selected.oriflamme.violence.dice" 
-                    value="{{this.violence.dice}}" 
+                    <input type="number" name="system.capacites.selected.oriflamme.violence.dice"
+                    value="{{this.violence.dice}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                     <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.oriflamme.violence.fixe" 
-                    value="{{this.violence.fixe}}" 
+                    <input type="number" name="system.capacites.selected.oriflamme.violence.fixe"
+                    value="{{this.violence.fixe}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>

--- a/templates/items/armures/capacites/personnalise.html
+++ b/templates/items/armures/capacites/personnalise.html
@@ -1,5 +1,5 @@
 <div class="personnalise">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PERSONNALISE.Label"}}
         <div>

--- a/templates/items/armures/capacites/puppet.html
+++ b/templates/items/armures/capacites/puppet.html
@@ -1,6 +1,6 @@
 
 <div class="puppet">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Label"}}
         <div>
@@ -25,19 +25,19 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Ordre"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.energie.ordre" value="{{this.energie.ordre}}" 
+                <input type="number" name="system.capacites.selected.puppet.energie.ordre" value="{{this.energie.ordre}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Creature"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.energie.supplementaire" value="{{this.energie.supplementaire}}" 
+                <input type="number" name="system.capacites.selected.puppet.energie.supplementaire" value="{{this.energie.supplementaire}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Prolonger"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.energie.prolonger" value="{{this.energie.prolonger}}" 
+                <input type="number" name="system.capacites.selected.puppet.energie.prolonger" value="{{this.energie.prolonger}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -62,25 +62,25 @@
             <h4>{{localize "KNIGHT.LATERAL.Flux"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Ordre"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.flux.ordre" value="{{this.flux.ordre}}" 
+                <input type="number" name="system.capacites.selected.puppet.flux.ordre" value="{{this.flux.ordre}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Creature"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.flux.supplementaire" value="{{this.flux.supplementaire}}" 
+                <input type="number" name="system.capacites.selected.puppet.flux.supplementaire" value="{{this.flux.supplementaire}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Prolonger"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.flux.prolonger" value="{{this.flux.prolonger}}" 
+                <input type="number" name="system.capacites.selected.puppet.flux.prolonger" value="{{this.flux.prolonger}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan separation">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Max"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.creatures" value="{{this.creatures}}" 
+                <input type="number" name="system.capacites.selected.puppet.creatures" value="{{this.creatures}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armures/capacites/rage.html
+++ b/templates/items/armures/capacites/rage.html
@@ -1,6 +1,6 @@
 
 <div class="rage">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.Label"}}
         <div>
@@ -186,7 +186,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -201,7 +201,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -216,7 +216,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -236,7 +236,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -251,7 +251,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -266,7 +266,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -281,7 +281,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -296,7 +296,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -311,7 +311,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -379,7 +379,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -394,7 +394,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -409,7 +409,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -429,7 +429,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -444,7 +444,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -459,7 +459,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -474,7 +474,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -489,7 +489,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -504,7 +504,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -574,7 +574,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -589,7 +589,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -604,7 +604,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -624,7 +624,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -639,7 +639,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -654,7 +654,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -669,7 +669,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -684,7 +684,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>
@@ -699,7 +699,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                         {{/select}}
                     </select>
                 </label>

--- a/templates/items/armures/capacites/record.html
+++ b/templates/items/armures/capacites/record.html
@@ -1,6 +1,6 @@
 
 <div class="record">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RECORD.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.record.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.record.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -42,8 +42,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.record.duree" 
-                data-capacite="record" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.record.duree"
+                data-capacite="record" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armures/capacites/rewind.html
+++ b/templates/items/armures/capacites/rewind.html
@@ -1,6 +1,6 @@
 
 <div class="rewind">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.REWIND.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.rewind.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.rewind.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -42,8 +42,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.rewind.duree" 
-                data-capacite="rewind" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.rewind.duree"
+                data-capacite="rewind" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armures/capacites/sarcophage.html
+++ b/templates/items/armures/capacites/sarcophage.html
@@ -1,5 +1,5 @@
 <div class="sarcophage">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SARCOPHAGE.Label"}}
         <div>
@@ -25,7 +25,7 @@
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SARCOPHAGE.Paliers"}}</span>
                 <input type="number" name="system.capacites.selected.sarcophage.bonus.paliers" class="paliers" value="{{this.bonus.paliers}}"
                 min="0"
-                {{#if this.softlock}}disabled{{/if}} /> 
+                {{#if this.softlock}}disabled{{/if}} />
             </label>
         </div>
         <div class="data fullWidth">
@@ -38,17 +38,17 @@
                 </h4>
             </div>
             {{#each this.bonus.liste as | key bonus|}}
-                
+
                 <div class="line">
                     <div class="PG {{#if @last}}last{{/if}}">
-                        <input type="number" name="system.capacites.selected.sarcophage.bonus.liste.{{bonus}}.pg.min" value="{{this.pg.min}}" 
-                            min="0" 
-                            {{#if ../this.softlock}}disabled{{/if}}/> 
+                        <input type="number" name="system.capacites.selected.sarcophage.bonus.liste.{{bonus}}.pg.min" value="{{this.pg.min}}"
+                            min="0"
+                            {{#if ../this.softlock}}disabled{{/if}}/>
                         {{#unless @last}}
                         <span class="middle">-</span>
 
-                        <input type="number" name="system.capacites.selected.sarcophage.bonus.liste.{{bonus}}.pg.max" value="{{this.pg.max}}" 
-                            min="{{this.pg.min}}" 
+                        <input type="number" name="system.capacites.selected.sarcophage.bonus.liste.{{bonus}}.pg.max" value="{{this.pg.max}}"
+                            min="{{this.pg.min}}"
                             {{#if ../this.softlock}}disabled{{/if}}/>
                         {{/unless}}
                         {{#if @last}}
@@ -56,9 +56,9 @@
                         {{/if}}
                         <span class="label {{#if @last}}last{{/if}}">{{localize "KNIGHT.AUTRE.PointGloire-short"}}</span>
                     </div>
-                    
-                    <textarea style="height:{{lookup ../this.textarea @bonus }}px" 
-                        data-capacite="sarcophage" data-type="{{bonus}}" data-min="50" 
+
+                    <textarea style="height:{{lookup ../this.textarea @bonus }}px"
+                        data-capacite="sarcophage" data-type="{{bonus}}" data-min="50"
                         name="system.capacites.selected.sarcophage.bonus.liste.{{bonus}}.offert"
                     {{#if ../this.softlock}}disabled{{/if}}>{{this.offert}}</textarea>
                 </div>

--- a/templates/items/armures/capacites/shrine.html
+++ b/templates/items/armures/capacites/shrine.html
@@ -1,6 +1,6 @@
 
 <div class="shrine">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.Label"}}
         <div>
@@ -25,13 +25,13 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel"}}</span>
-                <input type="number" name="system.capacites.selected.shrine.energie.personnel" value="{{this.energie.personnel}}" 
+                <input type="number" name="system.capacites.selected.shrine.energie.personnel" value="{{this.energie.personnel}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance"}}</span>
-                <input type="number" name="system.capacites.selected.shrine.energie.distance" value="{{this.energie.distance}}" 
+                <input type="number" name="system.capacites.selected.shrine.energie.distance" value="{{this.energie.distance}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -40,13 +40,13 @@
             >{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Acces6Tours"}}</button>
             <label class="longspan {{#unless this.energie.acces6tours}}hidden{{/unless}}">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel6Tours"}}</span>
-                <input type="number" name="system.capacites.selected.shrine.energie.personnel6tours" value="{{this.energie.personnel6tours}}" 
+                <input type="number" name="system.capacites.selected.shrine.energie.personnel6tours" value="{{this.energie.personnel6tours}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan {{#unless this.energie.acces6tours}}hidden{{/unless}}">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance6Tours"}}</span>
-                <input type="number" name="system.capacites.selected.shrine.energie.distance6tours" value="{{this.energie.distance6tours}}" 
+                <input type="number" name="system.capacites.selected.shrine.energie.distance6tours" value="{{this.energie.distance6tours}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armures/capacites/totem.html
+++ b/templates/items/armures/capacites/totem.html
@@ -1,6 +1,6 @@
 
 <div class="totem">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Label"}}
         <div>
@@ -26,8 +26,8 @@
             <div class="double">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.ENERGIE.Matérialiser"}}</span>
                 <label class="block">
-                    <input type="number" name="system.capacites.selected.totem.energie.base" 
-                    value="{{this.energie.base}}" 
+                    <input type="number" name="system.capacites.selected.totem.energie.base"
+                    value="{{this.energie.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                     <span> / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Totem"}}</span>
@@ -36,8 +36,8 @@
             <div class="double">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.ENERGIE.Prolonger"}}</span>
                 <label class="block">
-                        <input type="number" name="system.capacites.selected.totem.energie.prolonger" 
-                    value="{{this.energie.prolonger}}" 
+                        <input type="number" name="system.capacites.selected.totem.energie.prolonger"
+                    value="{{this.energie.prolonger}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                     <span> / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Totem"}}</span>
@@ -45,15 +45,15 @@
             </div>
             <label class="longspan separation">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Nombre"}}</span>
-                <input type="number" name="system.capacites.selected.totem.nombre" 
-                value="{{this.nombre}}" 
+                <input type="number" name="system.capacites.selected.totem.nombre"
+                value="{{this.nombre}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.AUTRE.GainImpregnation"}}</span>
-                <input type="number" name="system.capacites.selected.totem.impregnation" 
-                value="{{this.impregnation}}" 
+                <input type="number" name="system.capacites.selected.totem.impregnation"
+                value="{{this.impregnation}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>

--- a/templates/items/armures/capacites/type.html
+++ b/templates/items/armures/capacites/type.html
@@ -1,6 +1,6 @@
 
 <div class="type">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.Label"}}
         <div>
@@ -24,23 +24,23 @@
         <div class="data plainData">
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TypesPossedes"}}</span>
-                <input type="number" name="system.capacites.selected.type.nbreType" 
-                value="{{this.nbreType}}" 
+                <input type="number" name="system.capacites.selected.type.nbreType"
+                value="{{this.nbreType}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <h4 class="separation">{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.ENERGIE.Tour"}}</span>
-                <input type="number" name="system.capacites.selected.type.energie.tour" 
-                value="{{this.energie.tour}}" 
+                <input type="number" name="system.capacites.selected.type.energie.tour"
+                value="{{this.energie.tour}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.ENERGIE.Scene"}}</span>
-                <input type="number" name="system.capacites.selected.type.energie.scene" 
-                value="{{this.energie.scene}}" 
+                <input type="number" name="system.capacites.selected.type.energie.scene"
+                value="{{this.energie.scene}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -58,7 +58,7 @@
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                 <textarea name="system.capacites.selected.type.duree"
-                data-capacite="type" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                data-capacite="type" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>
@@ -70,8 +70,8 @@
                 {{#each key.liste as | tKey dType|}}
                     <label class="doubleLine">
                         <span>{{tKey.label}}</span>
-                        <input type="number" name="system.capacites.selected.type.type.{{type}}.liste.{{dType}}.value" 
-                        value="{{this.value}}" 
+                        <input type="number" name="system.capacites.selected.type.type.{{type}}.liste.{{dType}}.value"
+                        value="{{this.value}}"
                         min="0"
                         {{#if ../../this.softlock}}disabled{{/if}} />
                     </label>

--- a/templates/items/armures/capacites/vision.html
+++ b/templates/items/armures/capacites/vision.html
@@ -1,6 +1,6 @@
 
 <div class="vision">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.VISION.Label"}}
         <div>
@@ -25,13 +25,13 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.AUTRE.Minimum"}}</span>
-                <input type="text" name="system.capacites.selected.vision.energie.min" value="{{this.energie.min}}" 
+                <input type="text" name="system.capacites.selected.vision.energie.min" value="{{this.energie.min}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.AUTRE.Maximum"}}</span>
-                <input type="text" name="system.capacites.selected.vision.energie.max" value="{{this.energie.max}}" 
+                <input type="text" name="system.capacites.selected.vision.energie.max" value="{{this.energie.max}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -49,7 +49,7 @@
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                 <textarea name="system.capacites.selected.vision.duree"
-                data-capacite="vision" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                data-capacite="vision" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armures/capacites/warlord.html
+++ b/templates/items/armures/capacites/warlord.html
@@ -1,5 +1,5 @@
 <div class="warlord">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}}
         <div>
@@ -24,8 +24,8 @@
             <div class="data">
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.NombresModes"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.selection" 
-                    value="{{this.impulsions.selection}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.selection"
+                    value="{{this.impulsions.selection}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -36,21 +36,21 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.BONUS.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.action.bonus.description"
-                    data-capacite="warlord" data-type="bonusAction" data-min="85" style="height:{{this.textarea.bonusAction}}px;" 
+                    data-capacite="warlord" data-type="bonusAction" data-min="85" style="height:{{this.textarea.bonusAction}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.action.bonus.description}}</textarea>
                 </label>
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.action.energie.allie" 
-                    value="{{this.impulsions.action.energie.allie}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.action.energie.allie"
+                    value="{{this.impulsions.action.energie.allie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.action.energie.porteur" 
-                    value="{{this.impulsions.action.energie.porteur}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.action.energie.porteur"
+                    value="{{this.impulsions.action.energie.porteur}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -68,7 +68,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.action.duree"
-                    data-capacite="warlord" data-type="dureeAction" data-min="50" style="height:{{this.textarea.dureeAction}}px;" 
+                    data-capacite="warlord" data-type="dureeAction" data-min="50" style="height:{{this.textarea.dureeAction}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.action.duree}}</textarea>
                 </label>
             </div>
@@ -77,7 +77,7 @@
                 <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.FORCE.Label"}}</h4>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.BONUS.ChampDeForce"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.force.bonus.champDeForce" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.force.bonus.champDeForce"
                     value="{{this.impulsions.force.bonus.champDeForce}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
@@ -85,22 +85,22 @@
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.force.energie.allie" 
-                    value="{{this.impulsions.force.energie.allie}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.force.energie.allie"
+                    value="{{this.impulsions.force.energie.allie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.force.energie.porteur" 
-                    value="{{this.impulsions.force.energie.porteur}}" 
+                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.force.energie.porteur"
+                    value="{{this.impulsions.force.energie.porteur}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.force.energie.prolonger" 
-                    value="{{this.impulsions.force.energie.prolonger}}" 
+                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.force.energie.prolonger"
+                    value="{{this.impulsions.force.energie.prolonger}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -118,7 +118,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.force.duree"
-                    data-capacite="warlord" data-type="dureeForce" data-min="50" style="height:{{this.textarea.dureeForce}}px;" 
+                    data-capacite="warlord" data-type="dureeForce" data-min="50" style="height:{{this.textarea.dureeForce}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.force.duree}}</textarea>
                 </label>
             </div>
@@ -128,22 +128,22 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.BONUS.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.energie.bonus.description"
-                    data-capacite="warlord" data-type="bonusEnergie" data-min="110" style="height:{{this.textarea.bonusEnergie}}px;" 
+                    data-capacite="warlord" data-type="bonusEnergie" data-min="110" style="height:{{this.textarea.bonusEnergie}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.energie.bonus.description}}</textarea>
                 </label>
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.AUTRE.Minimum"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.energie.energie.min" 
-                    value="{{this.impulsions.energie.energie.min}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.energie.energie.min"
+                    value="{{this.impulsions.energie.energie.min}}"
                     min="0"
                     max="{{this.impulsions.energie.energie.max}}"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.AUTRE.Maximum"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.energie.energie.max" 
-                    value="{{this.impulsions.energie.energie.max}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.energie.energie.max"
+                    value="{{this.impulsions.energie.energie.max}}"
                     min="{{this.impulsions.energie.energie.min}}"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -161,7 +161,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.energie.duree"
-                    data-capacite="warlord" data-type="dureeEnergie" data-min="50" style="height:{{this.textarea.dureeEnergie}}px;" 
+                    data-capacite="warlord" data-type="dureeEnergie" data-min="50" style="height:{{this.textarea.dureeEnergie}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.energie.duree}}</textarea>
                 </label>
             </div>
@@ -172,37 +172,37 @@
                 <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.ESQUIVE.Label"}}</h4>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.BONUS.Defense"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.bonus.defense" 
-                    value="{{this.impulsions.esquive.bonus.defense}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.bonus.defense"
+                    value="{{this.impulsions.esquive.bonus.defense}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.BONUS.Reaction"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.bonus.reaction" 
-                    value="{{this.impulsions.esquive.bonus.reaction}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.bonus.reaction"
+                    value="{{this.impulsions.esquive.bonus.reaction}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.allie" 
-                    value="{{this.impulsions.esquive.energie.allie}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.allie"
+                    value="{{this.impulsions.esquive.energie.allie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.porteur" 
-                    value="{{this.impulsions.esquive.energie.porteur}}" 
+                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.porteur"
+                    value="{{this.impulsions.esquive.energie.porteur}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.prolonger" 
-                    value="{{this.impulsions.esquive.energie.prolonger}}" 
+                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.prolonger"
+                    value="{{this.impulsions.esquive.energie.prolonger}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -220,7 +220,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.esquive.duree"
-                    data-capacite="warlord" data-type="dureeEsquive" data-min="50" style="height:{{this.textarea.dureeEsquive}}px;" 
+                    data-capacite="warlord" data-type="dureeEsquive" data-min="50" style="height:{{this.textarea.dureeEsquive}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.esquive.duree}}</textarea>
                 </label>
             </div>
@@ -230,7 +230,7 @@
                 <div class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.BONUS.Degats"}}</span>
                     <label>
-                        <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.bonus.degats" 
+                        <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.bonus.degats"
                         value="{{this.impulsions.guerre.bonus.degats}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
@@ -240,7 +240,7 @@
                 <div class="longspan">
                     <span>{{localize "KNIGHT.BONUS.Violence"}}</span>
                     <label>
-                        <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.bonus.violence" 
+                        <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.bonus.violence"
                         value="{{this.impulsions.guerre.bonus.violence}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
@@ -250,22 +250,22 @@
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.allie" 
-                    value="{{this.impulsions.guerre.energie.allie}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.allie"
+                    value="{{this.impulsions.guerre.energie.allie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.porteur" 
-                    value="{{this.impulsions.guerre.energie.porteur}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.porteur"
+                    value="{{this.impulsions.guerre.energie.porteur}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-                    <input class="absolute" type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.prolonger" 
-                    value="{{this.impulsions.guerre.energie.prolonger}}" 
+                    <input class="absolute" type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.prolonger"
+                    value="{{this.impulsions.guerre.energie.prolonger}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -283,7 +283,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.guerre.duree"
-                    data-capacite="warlord" data-type="dureeGuerre" data-min="50" style="height:{{this.textarea.dureeGuerre}}px;" 
+                    data-capacite="warlord" data-type="dureeGuerre" data-min="50" style="height:{{this.textarea.dureeGuerre}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.guerre.duree}}</textarea>
                 </label>
             </div>

--- a/templates/items/armures/capacites/watchtower.html
+++ b/templates/items/armures/capacites/watchtower.html
@@ -1,5 +1,5 @@
 <div class="watchtower">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WATCHTOWER.Label"}}
         <div>
@@ -23,8 +23,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.watchtower.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.watchtower.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -42,7 +42,7 @@
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                 <textarea name="system.capacites.selected.watchtower.duree"
-                data-capacite="watchtower" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                data-capacite="watchtower" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armures/capacites/windtalker.html
+++ b/templates/items/armures/capacites/windtalker.html
@@ -1,6 +1,6 @@
 
 <div class="windtalker">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WINDTALKER.Label"}}
         <div>
@@ -24,13 +24,13 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-                <input type="number" name="system.capacites.selected.windtalker.flux" value="{{this.flux}}" 
+                <input type="number" name="system.capacites.selected.windtalker.flux" value="{{this.flux}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.windtalker.energie" value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.windtalker.energie" value="{{this.energie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armures/capacites/zen.html
+++ b/templates/items/armures/capacites/zen.html
@@ -1,5 +1,5 @@
 <div class="zen">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ZEN.Label"}}
         <div>
@@ -25,8 +25,8 @@
             <div class="fullWidth">
                 <label class="longspan demiWidth">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ZEN.Difficulte"}}</span>
-                    <input type="number" name="system.capacites.selected.zen.difficulte" 
-                    value="{{this.difficulte}}" 
+                    <input type="number" name="system.capacites.selected.zen.difficulte"
+                    value="{{this.difficulte}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -36,7 +36,7 @@
                 <div class="aspect demiWidth">
                     <h4>{{getAspect aspect}}</h4>
                     {{#each key.caracteristiques  as | keyCarac caracteristique|}}
-                        <button type="action" 
+                        <button type="action"
                         data-type="zen" data-caracteristique="true" data-aspect="{{aspect}}" data-name="{{caracteristique}}" data-value="{{keyCarac.value}}"
                         class="{{#if keyCarac.value}}selected{{/if}} {{#unless ../../this.softlock}}notDisabled{{/unless}}">{{getCarac caracteristique}}</button>
                     {{/each}}

--- a/templates/items/armures/evolutions/apeiron.html
+++ b/templates/items/armures/evolutions/apeiron.html
@@ -1,16 +1,16 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.APEIRON.Label"}}
     </h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.BONUS.Espoir"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.special.apeiron.espoir.bonus" min="0" value="{{this.espoir.bonus}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.special.apeiron.espoir.bonus" min="0" value="{{this.espoir.bonus}}"
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.REDUCTION.Espoir"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.special.apeiron.espoir.reduction.value" min="0" value="{{this.espoir.reduction.value}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.special.apeiron.espoir.reduction.value" min="0" value="{{this.espoir.reduction.value}}"
         />
     </label>
 </div>

--- a/templates/items/armures/evolutions/ascension.html
+++ b/templates/items/armures/evolutions/ascension.html
@@ -1,29 +1,29 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ASCENSION.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.AUTRE.Minimum"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ascension.energie.min" 
-        value="{{this.energie.min}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ascension.energie.min"
+        value="{{this.energie.min}}"
         min="0"
         max="{{this.energie.max}}"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.AUTRE.Maximum"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ascension.energie.max" 
-        value="{{this.energie.max}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ascension.energie.max"
+        value="{{this.energie.max}}"
         min="0"
         max="{{this.energie.limite}}"
          />
     </label>
     <label class="longspan separation">
         <span>{{localize "KNIGHT.AUTRE.GainImpregnation"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ascension.impregnation" 
-        value="{{this.impregnation}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ascension.impregnation"
+        value="{{this.impregnation}}"
         min="0"
          />
     </label>

--- a/templates/items/armures/evolutions/borealis.html
+++ b/templates/items/armures/evolutions/borealis.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.SUPPORT.Label"}}
     </h4>
@@ -7,14 +7,14 @@
     <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.SUPPORT.Base"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.support.energie.base" value="{{this.support.energie.base}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.support.energie.base" value="{{this.support.energie.base}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.SUPPORT.Allie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.support.energie.allie" value="{{this.support.energie.allie}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.support.energie.allie" value="{{this.support.energie.allie}}"
+
         />
     </label>
     <label class="shortspan separation">
@@ -36,7 +36,7 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.OFFENSIF.Label"}}
     </h4>
@@ -49,22 +49,22 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.offensif.degats.dice" value="{{this.offensif.degats.dice}}" 
-               
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.offensif.degats.dice" value="{{this.offensif.degats.dice}}"
+
                 />
                 <span>D6</span>
-            </label>                
+            </label>
         </div>
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.offensif.violence.dice" value="{{this.offensif.violence.dice}}" 
-               
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.offensif.violence.dice" value="{{this.offensif.violence.dice}}"
+
                 />
                 <span>D6</span>
-            </label>                
+            </label>
         </div>
-    </div>            
+    </div>
     <label class="shortspan">
         <span>{{localize "KNIGHT.ACTIVATION.Label"}}</span>
         <select name="system.evolutions.liste.{{key}}.capacites.borealis.offensif.activation">
@@ -108,15 +108,15 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.BOREALIS.UTILITAIRE.Label"}}
     </h4>
     <textarea data-capacite="borealis" data-type="descriptionEUtilitaire" data-min="150" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.descriptionEUtilitaire}}px;" name="system.evolutions.liste.{{key}}.capacites.borealis.utilitaire.description">{{this.utilitaire.description}}</textarea>
     <label class="longspan simpleSeparation">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.utilitaire.energie" value="{{this.utilitaire.energie}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.borealis.utilitaire.energie" value="{{this.utilitaire.energie}}"
+
         />
     </label>
     <label class="shortspan separation">

--- a/templates/items/armures/evolutions/cea.html
+++ b/templates/items/armures/evolutions/cea.html
@@ -1,12 +1,12 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.energie" 
-        value="{{this.energie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.energie"
+        value="{{this.energie}}"
         min="0"
          />
     </label>
@@ -24,33 +24,33 @@
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.cea.duree" 
-        data-capacite="cea" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.cea.duree"
+        data-capacite="cea" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
     <label class="longspan separation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.Espoir"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.espoir" 
-        value="{{this.espoir}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.espoir"
+        value="{{this.espoir}}"
         min="0"
          />
     </label>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.SALVE.Label"}}
     </h4>
     <textarea name="system.evolutions.liste.{{key}}.capacites.cea.salve.description"
-    data-capacite="cea" data-type="descriptionSalve" data-min="70" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.descriptionSalve}}px;" 
+    data-capacite="cea" data-type="descriptionSalve" data-min="70" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.descriptionSalve}}px;"
     >{{this.salve.description}}</textarea>
     <div class="double">
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.salve.degats.dice" 
-                value="{{this.salve.degats.dice}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.salve.degats.dice"
+                value="{{this.salve.degats.dice}}"
                 min="0"
                  />
                 <span>D6</span>
@@ -60,8 +60,8 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.salve.violence.dice" 
-                value="{{this.salve.violence.dice}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.salve.violence.dice"
+                value="{{this.salve.violence.dice}}"
                 min="0"
                  />
                 <span>D6</span>
@@ -70,8 +70,8 @@
     </div>
     <label class="shortspan simpleSeparation">
         <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.cea.salve.portee" 
-        data-capacite="cea" data-type="porteeSalve" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.porteeSalve}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.cea.salve.portee"
+        data-capacite="cea" data-type="porteeSalve" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.porteeSalve}}px;"
         >{{this.salve.portee}}</textarea>
     </label>
     <div class="effets">
@@ -89,19 +89,19 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.VAGUE.Label"}}
     </h4>
     <textarea name="system.evolutions.liste.{{key}}.capacites.cea.vague.description"
-    data-capacite="cea" data-type="descriptionVague" data-min="70" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.descriptionVague}}px;" 
+    data-capacite="cea" data-type="descriptionVague" data-min="70" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.descriptionVague}}px;"
     >{{this.vague.description}}</textarea>
     <div class="double">
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.vague.degats.dice" 
-                value="{{this.vague.degats.dice}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.vague.degats.dice"
+                value="{{this.vague.degats.dice}}"
                 min="0"
                  />
                 <span>D6</span>
@@ -111,8 +111,8 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.vague.violence.dice" 
-                value="{{this.vague.violence.dice}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.vague.violence.dice"
+                value="{{this.vague.violence.dice}}"
                 min="0"
                  />
                 <span>D6</span>
@@ -121,8 +121,8 @@
     </div>
     <label class="shortspan simpleSeparation">
         <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.cea.vague.portee" 
-        data-capacite="cea" data-type="porteeVague" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.porteeVague}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.cea.vague.portee"
+        data-capacite="cea" data-type="porteeVague" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.porteeVague}}px;"
         >{{this.vague.portee}}</textarea>
     </label>
     <div class="effets">
@@ -140,19 +140,19 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CEA.RAYON.Label"}}
     </h4>
     <textarea name="system.evolutions.liste.{{key}}.capacites.cea.rayon.description"
-    data-capacite="cea" data-type="descriptionRayon" data-min="150" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.descriptionRayon}}px;" 
+    data-capacite="cea" data-type="descriptionRayon" data-min="150" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.descriptionRayon}}px;"
     >{{this.rayon.description}}</textarea>
     <div class="double">
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.rayon.degats.dice" 
-                value="{{this.rayon.degats.dice}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.rayon.degats.dice"
+                value="{{this.rayon.degats.dice}}"
                 min="0"
                  />
                 <span>D6</span>
@@ -162,19 +162,19 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.rayon.violence.dice" 
-                value="{{this.rayon.violence.dice}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.cea.rayon.violence.dice"
+                value="{{this.rayon.violence.dice}}"
                 min="0"
                  />
                 <span>D6</span>
             </label>
         </div>
     </div>
-    
+
     <label class="shortspan simpleSeparation">
         <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.cea.rayon.portee" 
-        data-capacite="cea" data-type="porteeRayon" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.porteeRayon}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.cea.rayon.portee"
+        data-capacite="cea" data-type="porteeRayon" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.porteeRayon}}px;"
         >{{this.rayon.portee}}</textarea>
     </label>
     <div class="effets">

--- a/templates/items/armures/evolutions/changeling.html
+++ b/templates/items/armures/evolutions/changeling.html
@@ -1,34 +1,34 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.Personnelle"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.energie.personnel" 
-        value="{{this.energie.personnel}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.energie.personnel"
+        value="{{this.energie.personnel}}"
         min="0"
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.Etendue"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.energie.etendue" 
-        value="{{this.energie.etendue}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.energie.etendue"
+        value="{{this.energie.etendue}}"
         min="0"
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.ParFauxEtres"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.energie.fauxEtre.value" 
-        value="{{this.energie.fauxEtre.value}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.energie.fauxEtre.value"
+        value="{{this.energie.fauxEtre.value}}"
         min="0"
         />
     </label>
     <label class="longspan separation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.FauxEtresMax"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.energie.fauxEtre.max" 
-        value="{{this.energie.fauxEtre.max}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.energie.fauxEtre.max"
+        value="{{this.energie.fauxEtre.max}}"
         min="0"
         />
     </label>
@@ -45,14 +45,14 @@
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.changeling.duree" 
-        data-capacite="changeling" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.changeling.duree"
+        data-capacite="changeling" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;"
        >{{this.duree}}</textarea>
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.changeling.portee" 
-            data-capacite="changeling" data-type="portee" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.portee}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.changeling.portee"
+            data-capacite="changeling" data-type="portee" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.portee}}px;"
            >{{this.portee}}</textarea>
     </label>
 
@@ -77,32 +77,32 @@
             <div class="tripleLine">
                 <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
                 <label>
-                    <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.desactivationexplosive.degats.dice" 
-                    value="{{this.desactivationexplosive.degats.dice}}" 
+                    <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.desactivationexplosive.degats.dice"
+                    value="{{this.desactivationexplosive.degats.dice}}"
                     min="0"
-                    />                    
+                    />
                     <span class="D6">D6+</span>
-                    <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.desactivationexplosive.degats.fixe" 
-                    value="{{this.desactivationexplosive.degats.fixe}}" 
+                    <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.desactivationexplosive.degats.fixe"
+                    value="{{this.desactivationexplosive.degats.fixe}}"
                     min="0"
-                    />    
+                    />
                 </label>
             </div>
             <div class="tripleLine">
                 <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
                 <label>
-                    <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.desactivationexplosive.violence.dice" 
-                    value="{{this.desactivationexplosive.violence.dice}}" 
+                    <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.desactivationexplosive.violence.dice"
+                    value="{{this.desactivationexplosive.violence.dice}}"
                     min="0"
-                    />                    
+                    />
                     <span class="D6">D6+</span>
-                    <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.desactivationexplosive.violence.fixe" 
-                    value="{{this.desactivationexplosive.violence.fixe}}" 
+                    <input type="number" name="system.evolutions.liste.{{key}}.capacites.changeling.desactivationexplosive.violence.fixe"
+                    value="{{this.desactivationexplosive.violence.fixe}}"
                     min="0"
-                    />    
+                    />
                 </label>
             </div>
-        </div>        
+        </div>
         <div class="{{#unless this.desactivationexplosive.acces}}hidden {{else}} effets {{/unless}}">
             {{#each this.desactivationexplosive.effets.liste as | key effet|}}
             <div>

--- a/templates/items/armures/evolutions/companions.html
+++ b/templates/items/armures/evolutions/companions.html
@@ -1,5 +1,5 @@
 <div class="liste">
-    <h2 class="header headerInLine">
+    <h2 class="header headerInLine js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.EVOLUTIONS.LabelParPaliers"}}
 
@@ -13,7 +13,7 @@
 
     <div class="mainData">
         <div class="data">
-            <h4 class="title">
+            <h4 class="title js-toggler">
                 <i class="far fa-minus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Label"}}
             </h4>
@@ -57,7 +57,7 @@
         </div>
 
         <div class="data">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.CEvolutions"}}</span>
             </h4>
@@ -88,7 +88,7 @@
         </div>
 
         <div class="data">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CEvolutions"}}</span>
             </h4>
@@ -119,7 +119,7 @@
         </div>
 
         <div class="data">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.CROW.CEvolutions"}}</span>
             </h4>

--- a/templates/items/armures/evolutions/contrecoups.html
+++ b/templates/items/armures/evolutions/contrecoups.html
@@ -1,6 +1,6 @@
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.CONTRECOUPS.Label"}}
     </h4>
@@ -22,7 +22,7 @@
                             <option value="{{carac}}">{{getCarac carac}}</option>
                         {{/each}}
                     </optgroup>
-                {{/each}}                    
+                {{/each}}
             {{/select}}
         </select>
         <select name="system.evolutions.liste.{{key}}.special.contrecoups.jet.c2">
@@ -34,7 +34,7 @@
                             <option value="{{carac}}">{{getCarac carac}}</option>
                         {{/each}}
                     </optgroup>
-                {{/each}}                    
+                {{/each}}
             {{/select}}
         </select>
     </div>
@@ -59,7 +59,7 @@
 </div>
 
 <div class="data fullWidth">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.CONTRECOUPS.Label"}}
     </h4>

--- a/templates/items/armures/evolutions/discord.html
+++ b/templates/items/armures/evolutions/discord.html
@@ -1,19 +1,19 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Tour"}}</h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.tour.flux" value="{{this.tour.flux}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.tour.flux" value="{{this.tour.flux}}"
+
         />
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.tour.energie" value="{{this.tour.energie}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.tour.energie" value="{{this.tour.energie}}"
+
         />
     </label>
     <label class="shortspan">
@@ -34,14 +34,14 @@
     <h4 class="separation">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Scene"}}</h4>
     <label class="shortspan noSeparation">
         <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.scene.flux" value="{{this.scene.flux}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.scene.flux" value="{{this.scene.flux}}"
+
         />
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.scene.energie" value="{{this.scene.energie}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.scene.energie" value="{{this.scene.energie}}"
+
         />
     </label>
     <label class="shortspan">
@@ -61,20 +61,20 @@
     </label>
     <label class="longspan separation">
         <span>{{localize "KNIGHT.MALUS.Actions"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.malus.actions" value="{{this.malus.actions}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.malus.actions" value="{{this.malus.actions}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.MALUS.Reaction"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.malus.reaction" value="{{this.malus.reaction}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.malus.reaction" value="{{this.malus.reaction}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.MALUS.Defense"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.malus.defense" value="{{this.malus.defense}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.discord.malus.defense" value="{{this.malus.defense}}"
+
         />
     </label>
 </div>

--- a/templates/items/armures/evolutions/falcon.html
+++ b/templates/items/armures/evolutions/falcon.html
@@ -1,14 +1,14 @@
 
-    
+
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FALCON.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.falcon.energie" 
-        value="{{this.energie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.falcon.energie"
+        value="{{this.energie}}"
         min="0"
          />
     </label>
@@ -25,8 +25,8 @@
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.falcon.duree" 
-        data-capacite="falcon" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.falcon.duree"
+        data-capacite="falcon" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
     <div class="plainData">

--- a/templates/items/armures/evolutions/forward.html
+++ b/templates/items/armures/evolutions/forward.html
@@ -1,12 +1,12 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FORWARD.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.forward.energie" 
-        value="{{this.energie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.forward.energie"
+        value="{{this.energie}}"
         min="0"
          />
     </label>
@@ -23,8 +23,8 @@
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.forward.duree" 
-        data-capacite="forward" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.forward.duree"
+        data-capacite="forward" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
 </div>

--- a/templates/items/armures/evolutions/ghost.html
+++ b/templates/items/armures/evolutions/ghost.html
@@ -1,21 +1,21 @@
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.ENERGIE.Tour"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ghost.energie.tour" 
-        value="{{this.energie.tour}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ghost.energie.tour"
+        value="{{this.energie.tour}}"
         min="0"
             />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.ENERGIE.Minute"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ghost.energie.minute" 
-        value="{{this.energie.minute}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.ghost.energie.minute"
+        value="{{this.energie.minute}}"
         min="0"
             />
     </label>
@@ -32,8 +32,8 @@
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.ghost.duree" 
-        data-capacite="ghost" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.ghost.duree"
+        data-capacite="ghost" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
     <button type="action" class=" {{#if this.interruption.actif}}selected{{/if}}"

--- a/templates/items/armures/evolutions/goliath.html
+++ b/templates/items/armures/evolutions/goliath.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GOLIATH.Label"}}
     </h4>

--- a/templates/items/armures/evolutions/illumination.html
+++ b/templates/items/armures/evolutions/illumination.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}}
     </h4>
@@ -21,9 +21,9 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
-        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} : 
+        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.CANDLE.Label"}}
     </h4>
     <textarea data-capacite="illumination" data-type="candle" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.candle}}px;" name="system.evolutions.liste.{{key}}.capacites.illumination.candle.description">{{this.candle.description}}</textarea>
@@ -47,9 +47,9 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
-        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} : 
+        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.TORCH.Label"}}
     </h4>
     <textarea data-capacite="illumination" data-type="torch" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.torch}}px;" name="system.evolutions.liste.{{key}}.capacites.illumination.torch.description">{{this.torch.description}}</textarea>
@@ -81,9 +81,9 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
-        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} : 
+        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.LIGHTHOUSE.Label"}}
     </h4>
     <textarea data-capacite="illumination" data-type="lighthouse" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.lighthouse}}px;" name="system.evolutions.liste.{{key}}.capacites.illumination.lighthouse.description">{{this.lighthouse.description}}</textarea>
@@ -111,9 +111,9 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
-        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} : 
+        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.LANTERN.Label"}}
     </h4>
     <textarea data-capacite="illumination" data-type="lantern" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.lantern}}px;" name="system.evolutions.liste.{{key}}.capacites.illumination.lantern.description">{{this.lantern.description}}</textarea>
@@ -158,9 +158,9 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
-        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} : 
+        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.BLAZE.Label"}}
     </h4>
     <textarea data-capacite="illumination" data-type="blaze" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.blaze}}px;" name="system.evolutions.liste.{{key}}.capacites.illumination.blaze.description">{{this.blaze.description}}</textarea>
@@ -198,9 +198,9 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
-        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} : 
+        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.BEACON.Label"}}
     </h4>
     <textarea data-capacite="illumination" data-type="beacon" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.beacon}}px;" name="system.evolutions.liste.{{key}}.capacites.illumination.beacon.description">{{this.beacon.description}}</textarea>
@@ -232,9 +232,9 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
-        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} : 
+        {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.PROJECTOR.Label"}}
     </h4>
     <textarea data-capacite="illumination" data-type="projector" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.projector}}px;" name="system.evolutions.liste.{{key}}.capacites.illumination.projector.description">{{this.projector.description}}</textarea>

--- a/templates/items/armures/evolutions/impregnation.html
+++ b/templates/items/armures/evolutions/impregnation.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.IMPREGNATION.Label"}}
     </h4>
@@ -14,7 +14,7 @@
                             <option value="{{carac}}">{{getCarac carac}}</option>
                         {{/each}}
                     </optgroup>
-                {{/each}}                    
+                {{/each}}
             {{/select}}
         </select>
         <select name="system.evolutions.liste.{{key}}.special.impregnation.jets.c2a" class="center">
@@ -26,7 +26,7 @@
                             <option value="{{carac}}">{{getCarac carac}}</option>
                         {{/each}}
                     </optgroup>
-                {{/each}}                    
+                {{/each}}
             {{/select}}
         </select>
     </div>
@@ -40,7 +40,7 @@
                             <option value="{{carac}}">{{getCarac carac}}</option>
                         {{/each}}
                     </optgroup>
-                {{/each}}                    
+                {{/each}}
             {{/select}}
         </select>
         <select name="system.evolutions.liste.{{key}}.special.impregnation.jets.c2b" class="center">
@@ -52,7 +52,7 @@
                             <option value="{{carac}}">{{getCarac carac}}</option>
                         {{/each}}
                     </optgroup>
-                {{/each}}                    
+                {{/each}}
             {{/select}}
         </select>
     </div>

--- a/templates/items/armures/evolutions/lenteetlourde.html
+++ b/templates/items/armures/evolutions/lenteetlourde.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.LENTEETLOURDE.Label"}}
     </h4>

--- a/templates/items/armures/evolutions/longbow.html
+++ b/templates/items/armures/evolutions/longbow.html
@@ -1,13 +1,13 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.PORTEE.Label"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.PORTEE.Cout"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.portee.energie" value="{{this.portee.energie}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.portee.energie" value="{{this.portee.energie}}"
+
         />
     </label>
     <label class="middlespan">
@@ -35,39 +35,39 @@
     <h4 class="separation">{{localize "KNIGHT.AUTRE.Degats"}}</h4>
     <label class="longspan noSeparation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.DEGATS.Cout"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.degats.energie" value="{{this.degats.energie}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.degats.energie" value="{{this.degats.energie}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.DEGATS.Min"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.degats.min" value="{{this.degats.min}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.degats.min" value="{{this.degats.min}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.DEGATS.Max"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.degats.max" value="{{this.degats.max}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.degats.max" value="{{this.degats.max}}"
+
         />
     </label>
     <h4 class="separation">{{localize "KNIGHT.AUTRE.Violence"}}</h4>
     <label class="longspan noSeparation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.VIOLENCE.Cout"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.violence.energie" value="{{this.violence.energie}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.violence.energie" value="{{this.violence.energie}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.VIOLENCE.Min"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.violence.min" value="{{this.violence.min}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.violence.min" value="{{this.violence.min}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.LONGBOW.VIOLENCE.Max"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.violence.max" value="{{this.violence.max}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.longbow.violence.max" value="{{this.violence.max}}"
+
         />
     </label>
     <div class="blockSecondaire">

--- a/templates/items/armures/evolutions/mechanic.html
+++ b/templates/items/armures/evolutions/mechanic.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Label"}}
     </h4>

--- a/templates/items/armures/evolutions/morph.html
+++ b/templates/items/armures/evolutions/morph.html
@@ -1,18 +1,18 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.energie" value="{{this.energie}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.energie" value="{{this.energie}}"
+
         />
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Espoir"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.espoir" value="{{this.espoir}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.espoir" value="{{this.espoir}}"
+
         />
     </label>
     <label class="shortspan">
@@ -25,21 +25,21 @@
             <option value="deplacement">{{localize "KNIGHT.ACTIVATION.Deplacement"}}</option>
             {{/select}}
         </select>
-    </label>           
+    </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea data-capacite="morph" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;" name="system.evolutions.liste.{{key}}.capacites.morph.duree">{{this.duree}}</textarea>
     </label>
     <label class="longspan separation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.NbreCapacites"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.capacites" value="{{this.capacites}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.capacites" value="{{this.capacites}}"
+
         />
     </label>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.VOL.Label"}}
     </h4>
@@ -47,15 +47,15 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.PHASE.Label"}}
     </h4>
     <textarea data-capacite="morph" data-type="phase" data-min="115" style="height:{{this.textarea.phase}}px;" name="system.evolutions.liste.{{key}}.capacites.morph.phase.description">{{this.phase.description}}</textarea>
     <label class="shortspan simpleSeparation">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.phase.energie" value="{{this.phase.energie}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.phase.energie" value="{{this.phase.energie}}"
+
         />
     </label>
     <label class="shortspan">
@@ -76,59 +76,59 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.ETIREMENT.Label"}}
     </h4>
     <textarea data-capacite="morph" data-type="etirement" data-min="130" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.etirement}}px;" name="system.evolutions.liste.{{key}}.capacites.morph.etirement.description">{{this.etirement.description}}</textarea>
     <label class="shortspan simpleSeparation">
         <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.morph.etirement.portee" 
-        data-capacite="morph" data-type="etirementPortee" data-min="50" style="height:{{this.textarea.etirementPortee}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.morph.etirement.portee"
+        data-capacite="morph" data-type="etirementPortee" data-min="50" style="height:{{this.textarea.etirementPortee}}px;"
        >{{this.etirement.portee}}</textarea>
     </label>
     <label class="longspan separation absolute">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.ETIREMENT.Bonus"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.etirement.bonus" value="{{this.etirement.bonus}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.etirement.bonus" value="{{this.etirement.bonus}}"
+
         />
     </label>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.METAL.Label"}}
     </h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.BONUS.ChampDeForce"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.metal.bonus.champDeForce" value="{{this.metal.bonus.champDeForce}}" 
-       
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.metal.bonus.champDeForce" value="{{this.metal.bonus.champDeForce}}"
+
         />
     </label>
 </div>
 
 <div class="data double">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.FLUIDE.Label"}}
     </h4>
     <div class="double">
         <label class="doubleLine">
             <span>{{localize "KNIGHT.BONUS.Defense"}}</span>
-            <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.fluide.bonus.defense" value="{{this.fluide.bonus.defense}}" 
+            <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.fluide.bonus.defense" value="{{this.fluide.bonus.defense}}"
             />
         </label>
         <label class="doubleLine">
             <span>{{localize "KNIGHT.BONUS.Reaction"}}</span>
-            <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.fluide.bonus.reaction" value="{{this.fluide.bonus.reaction}}" 
+            <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.fluide.bonus.reaction" value="{{this.fluide.bonus.reaction}}"
             />
         </label>
     </div>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MORPH.CAPACITES.POLYMORPHIE.Label"}}
     </h4>
@@ -150,8 +150,8 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.griffe.degats.dice" value="{{this.polymorphie.griffe.degats.dice}}" 
-               
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.griffe.degats.dice" value="{{this.polymorphie.griffe.degats.dice}}"
+
                 />
                 <span class="{{localize "KNIGHT.JETS.Des-short"}}6 {{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
             </label>
@@ -159,8 +159,8 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.griffe.violence.dice" value="{{this.polymorphie.griffe.violence.dice}}" 
-               
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.griffe.violence.dice" value="{{this.polymorphie.griffe.violence.dice}}"
+
                 />
                 <span class="{{localize "KNIGHT.JETS.Des-short"}}6 {{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
             </label>
@@ -197,8 +197,8 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.lame.degats.dice" value="{{this.polymorphie.lame.degats.dice}}" 
-               
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.lame.degats.dice" value="{{this.polymorphie.lame.degats.dice}}"
+
                 />
                 <span class="{{localize "KNIGHT.JETS.Des-short"}}6 {{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
             </label>
@@ -206,8 +206,8 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.lame.violence.dice" value="{{this.polymorphie.lame.violence.dice}}" 
-               
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.lame.violence.dice" value="{{this.polymorphie.lame.violence.dice}}"
+
                 />
                 <span class="{{localize "KNIGHT.JETS.Des-short"}}6 {{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
             </label>
@@ -243,8 +243,8 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.canon.degats.dice" value="{{this.polymorphie.canon.degats.dice}}" 
-               
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.canon.degats.dice" value="{{this.polymorphie.canon.degats.dice}}"
+
                 />
                 <span class="{{localize "KNIGHT.JETS.Des-short"}}6 {{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
             </label>
@@ -252,8 +252,8 @@
         <div class="doubleLine">
             <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.canon.violence.dice" value="{{this.polymorphie.canon.violence.dice}}" 
-               
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.morph.polymorphie.canon.violence.dice" value="{{this.polymorphie.canon.violence.dice}}"
+
                 />
                 <span class="{{localize "KNIGHT.JETS.Des-short"}}6 {{#unless this.softlock}}notdisabled{{/unless}}">{{localize "KNIGHT.JETS.Des-short"}}6</span>
             </label>

--- a/templates/items/armures/evolutions/nanoc.html
+++ b/templates/items/armures/evolutions/nanoc.html
@@ -1,34 +1,34 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ObjetBase"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.nanoc.energie.base" 
-        value="{{this.energie.base}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.nanoc.energie.base"
+        value="{{this.energie.base}}"
         min="0"
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ObjetDetaille"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.nanoc.energie.detaille" 
-        value="{{this.energie.detaille}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.nanoc.energie.detaille"
+        value="{{this.energie.detaille}}"
         min="0"
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ObjetMecanique"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.nanoc.energie.mecanique" 
-        value="{{this.energie.mecanique}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.nanoc.energie.mecanique"
+        value="{{this.energie.mecanique}}"
         min="0"
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.AUTRE.Prolonger"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ParMinute"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.nanoc.energie.prolonger" 
-        value="{{this.energie.prolonger}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.nanoc.energie.prolonger"
+        value="{{this.energie.prolonger}}"
         min="0"
         />
     </label>
@@ -47,7 +47,7 @@
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.nanoc.duree"
-        data-capacite="nanoc" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;" 
+        data-capacite="nanoc" data-type="duree" data-min="50" data-key="{{key}}" data-evolution="true" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
 </div>

--- a/templates/items/armures/evolutions/oriflamme.html
+++ b/templates/items/armures/evolutions/oriflamme.html
@@ -1,12 +1,12 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ORIFLAMME.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.energie" 
-        value="{{this.energie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.energie"
+        value="{{this.energie}}"
         min="0"
          />
     </label>
@@ -24,8 +24,8 @@
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.oriflamme.duree" 
-        data-capacite="oriflamme" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"  
+        <textarea name="system.evolutions.liste.{{key}}.capacites.oriflamme.duree"
+        data-capacite="oriflamme" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
     <label class="shortspan">
@@ -44,13 +44,13 @@
         <div class="tripleLine">
             <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.degats.dice" 
-                value="{{this.degats.dice}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.degats.dice"
+                value="{{this.degats.dice}}"
                 min="0"
                  />
                 <span>D6+</span>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.degats.fixe" 
-                value="{{this.degats.fixe}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.degats.fixe"
+                value="{{this.degats.fixe}}"
                 min="0"
                  />
             </label>
@@ -58,13 +58,13 @@
         <div class="tripleLine">
             <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
             <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.violence.dice" 
-                value="{{this.degats.dice}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.violence.dice"
+                value="{{this.degats.dice}}"
                 min="0"
                  />
                 <span>D6+</span>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.violence.fixe" 
-                value="{{this.degats.fixe}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.oriflamme.violence.fixe"
+                value="{{this.degats.fixe}}"
                 min="0"
                  />
             </label>

--- a/templates/items/armures/evolutions/plusespoir.html
+++ b/templates/items/armures/evolutions/plusespoir.html
@@ -1,12 +1,12 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PLUSESPOIR.Label"}}
     </h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PLUSESPOIR.ESPOIR.Label"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.special.plusespoir.espoir.base" 
-            value="{{this.espoir.base}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.special.plusespoir.espoir.base"
+            value="{{this.espoir.base}}"
             min="0"
             />
     </label>

--- a/templates/items/armures/evolutions/porteurlumiere.html
+++ b/templates/items/armures/evolutions/porteurlumiere.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PORTEURLUMIERE.Label"}}
     </h4>

--- a/templates/items/armures/evolutions/puppet.html
+++ b/templates/items/armures/evolutions/puppet.html
@@ -1,25 +1,25 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Ordre"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.energie.ordre" value="{{this.energie.ordre}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.energie.ordre" value="{{this.energie.ordre}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Creature"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.energie.supplementaire" value="{{this.energie.supplementaire}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.energie.supplementaire" value="{{this.energie.supplementaire}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Prolonger"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.energie.prolonger" value="{{this.energie.prolonger}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.energie.prolonger" value="{{this.energie.prolonger}}"
+
         />
     </label>
     <label class="shortspan separation">
@@ -40,32 +40,32 @@
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Label"}} : {{localize "KNIGHT.LATERAL.Flux"}}
     </h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Ordre"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.flux.ordre" value="{{this.flux.ordre}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.flux.ordre" value="{{this.flux.ordre}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Creature"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.flux.supplementaire" value="{{this.flux.supplementaire}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.flux.supplementaire" value="{{this.flux.supplementaire}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Prolonger"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.flux.prolonger" value="{{this.flux.prolonger}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.flux.prolonger" value="{{this.flux.prolonger}}"
+
         />
     </label>
     <label class="longspan separation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Max"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.creatures" value="{{this.creatures}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.puppet.creatures" value="{{this.creatures}}"
+
         />
     </label>
 </div>

--- a/templates/items/armures/evolutions/rage.html
+++ b/templates/items/armures/evolutions/rage.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.Label"}}
     </h4>
@@ -25,7 +25,7 @@
 </div>
 
 <div class="data rageFull">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.NOURRI.Label"}}
@@ -110,7 +110,7 @@
 
 <div class="col">
     <div class="data">
-        <h4 class="title">
+        <h4 class="title js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.Label"}} :
             {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.COLERE.Label"}}
@@ -175,7 +175,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -190,7 +190,7 @@
                             <option value="{{carac}}">{{getCarac carac}}</option>
                         {{/each}}
                     </optgroup>
-                {{/each}}                    
+                {{/each}}
                 {{/select}}
             </select>
             </label>
@@ -205,7 +205,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -228,7 +228,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -243,7 +243,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -258,7 +258,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -273,7 +273,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -288,7 +288,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -303,16 +303,16 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
         </div>
-        
+
     </div>
 
     <div class="data">
-        <h4 class="title">
+        <h4 class="title js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.Label"}} :
             {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.RAGE.Label"}}
@@ -378,7 +378,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -393,7 +393,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -408,12 +408,12 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
         </div>
-        
+
         <button type="action" class="{{#if this.rage.combosInterdits.has}}selected{{/if}}"
         data-key="{{key}}" data-type="rage" data-subtype="rage" data-anothersubtype="combosInterdits" data-name="has" data-value="{{this.rage.combosInterdits.has}}"
         >
@@ -432,7 +432,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -447,7 +447,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -462,7 +462,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -477,7 +477,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -492,7 +492,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -507,7 +507,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -517,7 +517,7 @@
 
 <div class="col">
     <div class="data">
-        <h4 class="title">
+        <h4 class="title js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.Label"}} :
             {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.FUREUR.Label"}}
@@ -583,7 +583,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -598,7 +598,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -613,12 +613,12 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
         </div>
-        
+
         <button type="action" class="{{#if this.fureur.combosInterdits.has}}selected{{/if}}"
         data-key="{{key}}" data-type="rage" data-subtype="fureur" data-anothersubtype="combosInterdits" data-name="has" data-value="{{this.fureur.combosInterdits.has}}"
         >
@@ -636,7 +636,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -651,7 +651,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -666,7 +666,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -681,7 +681,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -696,7 +696,7 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
@@ -711,17 +711,17 @@
                                 <option value="{{carac}}">{{getCarac carac}}</option>
                             {{/each}}
                         </optgroup>
-                    {{/each}}                    
+                    {{/each}}
                     {{/select}}
                 </select>
             </label>
         </div>
-        
+
     </div>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RAGE.Label"}} :
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ILLUMINATION.BLAZE.Label"}}
@@ -734,7 +734,7 @@
             <input type="number" name="system.evolutions.liste.{{key}}.capacites.rage.blaze.degats" value="{{this.blaze.degats}}" />
             <span class="special">D6</span>
         </label>
-        
+
     </label>
     <label class="doubleInline">
         <span class="title">{{localize "KNIGHT.AUTRE.Violence"}}</span>

--- a/templates/items/armures/evolutions/record.html
+++ b/templates/items/armures/evolutions/record.html
@@ -1,12 +1,12 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RECORD.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.record.energie" 
-        value="{{this.energie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.record.energie"
+        value="{{this.energie}}"
         min="0"
          />
     </label>
@@ -23,8 +23,8 @@
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.record.duree" 
-        data-capacite="record" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.record.duree"
+        data-capacite="record" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
 </div>

--- a/templates/items/armures/evolutions/rewind.html
+++ b/templates/items/armures/evolutions/rewind.html
@@ -1,12 +1,12 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.REWIND.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.rewind.energie" 
-        value="{{this.energie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.rewind.energie"
+        value="{{this.energie}}"
         min="0"
          />
     </label>
@@ -23,8 +23,8 @@
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-        <textarea name="system.evolutions.liste.{{key}}.capacites.rewind.duree" 
-        data-capacite="rewind" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;" 
+        <textarea name="system.evolutions.liste.{{key}}.capacites.rewind.duree"
+        data-capacite="rewind" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
 </div>

--- a/templates/items/armures/evolutions/shrine.html
+++ b/templates/items/armures/evolutions/shrine.html
@@ -1,19 +1,19 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.shrine.energie.personnel" value="{{this.energie.personnel}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.shrine.energie.personnel" value="{{this.energie.personnel}}"
+
         />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.shrine.energie.distance" value="{{this.energie.distance}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.shrine.energie.distance" value="{{this.energie.distance}}"
+
         />
     </label>
     <button type="action" data-key="{{key}}" data-type="shrine" data-subtype="energie" data-name="acces6tours" data-value="{{this.energie.acces6tours}}"
@@ -21,14 +21,14 @@
     >{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Acces6Tours"}}</button>
     <label class="longspan {{#unless this.energie.acces6tours}}hidden{{/unless}} noSeparation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel6Tours"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.shrine.energie.personnel6tours" value="{{this.energie.personnel6tours}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.shrine.energie.personnel6tours" value="{{this.energie.personnel6tours}}"
+
         />
     </label>
     <label class="longspan {{#unless this.energie.acces6tours}}hidden{{/unless}}">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance6Tours"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.shrine.energie.distance6tours" value="{{this.energie.distance6tours}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.shrine.energie.distance6tours" value="{{this.energie.distance6tours}}"
+
         />
     </label>
     <label class="shortspan separation">

--- a/templates/items/armures/evolutions/totem.html
+++ b/templates/items/armures/evolutions/totem.html
@@ -1,5 +1,5 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Label"}}
     </h4>
@@ -7,8 +7,8 @@
     <div class="middlespan withSpecialLong noSeparation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.ENERGIE.Matérialiser"}}</span>
         <label>
-            <input type="number" name="system.evolutions.liste.{{key}}.capacites.totem.energie.base" 
-            value="{{this.energie.base}}" 
+            <input type="number" name="system.evolutions.liste.{{key}}.capacites.totem.energie.base"
+            value="{{this.energie.base}}"
             min="0"
              />
             <span> / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Totem"}}</span>
@@ -17,8 +17,8 @@
     <div class="middlespan withSpecialLong">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.ENERGIE.Prolonger"}}</span>
         <label>
-                <input type="number" name="system.evolutions.liste.{{key}}.capacites.totem.energie.prolonger" 
-            value="{{this.energie.prolonger}}" 
+                <input type="number" name="system.evolutions.liste.{{key}}.capacites.totem.energie.prolonger"
+            value="{{this.energie.prolonger}}"
             min="0"
              />
             <span> / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Totem"}}</span>
@@ -26,15 +26,15 @@
     </div>
     <label class="longspan separation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Nombre"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.totem.nombre" 
-        value="{{this.nombre}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.totem.nombre"
+        value="{{this.nombre}}"
         min="0"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.AUTRE.GainImpregnation"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.totem.impregnation" 
-        value="{{this.impregnation}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.totem.impregnation"
+        value="{{this.impregnation}}"
         min="0"
          />
     </label>

--- a/templates/items/armures/evolutions/type.html
+++ b/templates/items/armures/evolutions/type.html
@@ -1,27 +1,27 @@
     <div class="data">
-        <h4 class="title">
+        <h4 class="title js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.Label"}}
         </h4>
         <label class="longspan">
             <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TypesPossedes"}}</span>
-            <input type="number" name="system.evolutions.liste.{{key}}.capacites.type.nbreType" 
-            value="{{this.nbreType}}" 
+            <input type="number" name="system.evolutions.liste.{{key}}.capacites.type.nbreType"
+            value="{{this.nbreType}}"
             min="0"
             />
         </label>
         <h4 class="separation">{{localize "KNIGHT.LATERAL.Energie"}}</h4>
         <label class="longspan">
             <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.ENERGIE.Tour"}}</span>
-            <input type="number" name="system.evolutions.liste.{{key}}.capacites.type.energie.tour" 
-            value="{{this.energie.tour}}" 
+            <input type="number" name="system.evolutions.liste.{{key}}.capacites.type.energie.tour"
+            value="{{this.energie.tour}}"
             min="0"
              />
         </label>
         <label class="longspan">
             <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.ENERGIE.Scene"}}</span>
-            <input type="number" name="system.evolutions.liste.{{key}}.capacites.type.energie.scene" 
-            value="{{this.energie.scene}}" 
+            <input type="number" name="system.evolutions.liste.{{key}}.capacites.type.energie.scene"
+            value="{{this.energie.scene}}"
             min="0"
              />
         </label>
@@ -39,14 +39,14 @@
         <label class="shortspan">
             <span>{{localize "KNIGHT.DUREE.Label"}}</span>
             <textarea name="system.evolutions.liste.{{key}}.capacites.type.duree"
-            data-capacite="type" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;" 
+            data-capacite="type" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"
             >{{this.duree}}</textarea>
         </label>
     </div>
 
     {{#each this.type as | tKey type|}}
         <div class="data">
-            <h4 class="title">
+            <h4 class="title js-toggler">
                 <i class="far fa-minus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.Label"}} : {{tKey.label}}
             </h4>
@@ -55,8 +55,8 @@
                 {{#each tKey.liste as | lKey dType|}}
                     <label class="tripleLine">
                         <span>{{lKey.label}}</span>
-                        <input type="number" name="system.evolutions.liste.{{../../key}}.capacites.type.type.{{type}}.liste.{{dType}}.value" 
-                        value="{{this.value}}" 
+                        <input type="number" name="system.evolutions.liste.{{../../key}}.capacites.type.type.{{type}}.liste.{{dType}}.value"
+                        value="{{this.value}}"
                         min="0"
                         />
                     </label>
@@ -64,4 +64,3 @@
             </div>
         </div>
     {{/each}}
-    

--- a/templates/items/armures/evolutions/vision.html
+++ b/templates/items/armures/evolutions/vision.html
@@ -1,19 +1,19 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.VISION.Label"}}
     </h4>
     <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.AUTRE.Minimum"}}</span>
-        <input type="text" name="system.evolutions.liste.{{key}}.capacites.vision.energie.min" value="{{this.energie.min}}" 
-        
+        <input type="text" name="system.evolutions.liste.{{key}}.capacites.vision.energie.min" value="{{this.energie.min}}"
+
         />
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.AUTRE.Maximum"}}</span>
-        <input type="text" name="system.evolutions.liste.{{key}}.capacites.vision.energie.max" value="{{this.energie.max}}" 
-        
+        <input type="text" name="system.evolutions.liste.{{key}}.capacites.vision.energie.max" value="{{this.energie.max}}"
+
         />
     </label>
     <label class="shortspan separation">
@@ -30,7 +30,7 @@
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.vision.duree"
-        data-capacite="vision" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;" 
+        data-capacite="vision" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
 </div>

--- a/templates/items/armures/evolutions/warlord.html
+++ b/templates/items/armures/evolutions/warlord.html
@@ -1,40 +1,40 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}}
     </h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.NombresModes"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.selection" 
-        value="{{this.impulsions.selection}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.selection"
+        value="{{this.impulsions.selection}}"
         min="0"
          />
     </label>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.ACTION.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.BONUS.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.action.bonus.description"
-        data-capacite="warlord" data-type="bonusAction" data-min="85"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.bonusAction}}px;" 
+        data-capacite="warlord" data-type="bonusAction" data-min="85"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.bonusAction}}px;"
         >{{this.impulsions.action.bonus.description}}</textarea>
     </label>
     <h4 class="separationTB">{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan noSeparation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.action.energie.allie" 
-        value="{{this.impulsions.action.energie.allie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.action.energie.allie"
+        value="{{this.impulsions.action.energie.allie}}"
         min="0"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.action.energie.porteur" 
-        value="{{this.impulsions.action.energie.porteur}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.action.energie.porteur"
+        value="{{this.impulsions.action.energie.porteur}}"
         min="0"
          />
     </label>
@@ -52,19 +52,19 @@
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.action.duree"
-        data-capacite="warlord" data-type="dureeAction" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeAction}}px;" 
+        data-capacite="warlord" data-type="dureeAction" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeAction}}px;"
         >{{this.impulsions.action.duree}}</textarea>
     </label>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.FORCE.Label"}}
     </h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.BONUS.ChampDeForce"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.bonus.champDeForce" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.bonus.champDeForce"
         value="{{this.impulsions.force.bonus.champDeForce}}"
         min="0"
          />
@@ -72,22 +72,22 @@
     <h4 class="separationTB">{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan ">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.energie.allie" 
-        value="{{this.impulsions.force.energie.allie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.energie.allie"
+        value="{{this.impulsions.force.energie.allie}}"
         min="0"
          />
     </label>
     <label class="longspan noSeparation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-        <input class="absolute"  type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.energie.porteur" 
-        value="{{this.impulsions.force.energie.porteur}}" 
+        <input class="absolute"  type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.energie.porteur"
+        value="{{this.impulsions.force.energie.porteur}}"
         min="0"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-        <input class="absolute"  type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.energie.prolonger" 
-        value="{{this.impulsions.force.energie.prolonger}}" 
+        <input class="absolute"  type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.energie.prolonger"
+        value="{{this.impulsions.force.energie.prolonger}}"
         min="0"
          />
     </label>
@@ -105,35 +105,35 @@
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.force.duree"
-        data-capacite="warlord" data-type="dureeForce" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeForce}}px;" 
+        data-capacite="warlord" data-type="dureeForce" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeForce}}px;"
         >{{this.impulsions.force.duree}}</textarea>
     </label>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.ENERGIE.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.BONUS.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.energie.bonus.description"
-        data-capacite="warlord" data-type="bonusEnergie" data-min="110"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.bonusEnergie}}px;" 
+        data-capacite="warlord" data-type="bonusEnergie" data-min="110"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.bonusEnergie}}px;"
         >{{this.impulsions.energie.bonus.description}}</textarea>
     </label>
     <h4 class="separationTB">{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan noSeparation">
         <span>{{localize "KNIGHT.AUTRE.Minimum"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.energie.energie.min" 
-        value="{{this.impulsions.energie.energie.min}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.energie.energie.min"
+        value="{{this.impulsions.energie.energie.min}}"
         min="0"
         max="{{this.impulsions.energie.energie.max}}"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.AUTRE.Maximum"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.energie.energie.max" 
-        value="{{this.impulsions.energie.energie.max}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.energie.energie.max"
+        value="{{this.impulsions.energie.energie.max}}"
         min="{{this.impulsions.energie.energie.min}}"
          />
     </label>
@@ -151,49 +151,49 @@
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.energie.duree"
-        data-capacite="warlord" data-type="dureeEnergie" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeEnergie}}px;" 
+        data-capacite="warlord" data-type="dureeEnergie" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeEnergie}}px;"
         >{{this.impulsions.energie.duree}}</textarea>
     </label>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.ESQUIVE.Label"}}
     </h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.BONUS.Defense"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.bonus.defense" 
-        value="{{this.impulsions.esquive.bonus.defense}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.bonus.defense"
+        value="{{this.impulsions.esquive.bonus.defense}}"
         min="0"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.BONUS.Reaction"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.bonus.reaction" 
-        value="{{this.impulsions.esquive.bonus.reaction}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.bonus.reaction"
+        value="{{this.impulsions.esquive.bonus.reaction}}"
         min="0"
          />
     </label>
     <h4 class="separationTB">{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan noSeparation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.energie.allie" 
-        value="{{this.impulsions.esquive.energie.allie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.energie.allie"
+        value="{{this.impulsions.esquive.energie.allie}}"
         min="0"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-        <input class="absolute"  type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.energie.porteur" 
-        value="{{this.impulsions.esquive.energie.porteur}}" 
+        <input class="absolute"  type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.energie.porteur"
+        value="{{this.impulsions.esquive.energie.porteur}}"
         min="0"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-        <input class="absolute"  type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.energie.prolonger" 
-        value="{{this.impulsions.esquive.energie.porteur}}" 
+        <input class="absolute"  type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.energie.prolonger"
+        value="{{this.impulsions.esquive.energie.porteur}}"
         min="0"
          />
     </label>
@@ -211,20 +211,20 @@
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.esquive.duree"
-        data-capacite="warlord" data-type="dureeEsquive" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeEsquive}}px;" 
+        data-capacite="warlord" data-type="dureeEsquive" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeEsquive}}px;"
         >{{this.impulsions.esquive.duree}}</textarea>
     </label>
 </div>
 
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}} : {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.GUERRE.Label"}}
     </h4>
     <div class="longspan withSpecial">
         <span>{{localize "KNIGHT.BONUS.Degats"}}</span>
         <label>
-            <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.bonus.degats" 
+            <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.bonus.degats"
             value="{{this.impulsions.guerre.bonus.degats}}"
             min="0"
              />
@@ -234,7 +234,7 @@
     <div class="longspan withSpecial">
         <span>{{localize "KNIGHT.BONUS.Violence"}}</span>
         <label>
-            <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.bonus.violence" 
+            <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.bonus.violence"
             value="{{this.impulsions.guerre.bonus.violence}}"
             min="0"
              />
@@ -244,22 +244,22 @@
     <h4 class="separationTB">{{localize "KNIGHT.LATERAL.Energie"}}</h4>
     <label class="longspan noSeparation">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.energie.allie" 
-        value="{{this.impulsions.guerre.energie.allie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.energie.allie"
+        value="{{this.impulsions.guerre.energie.allie}}"
         min="0"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-        <input class="absolute" type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.energie.prolonger" 
-        value="{{this.impulsions.guerre.energie.porteur}}" 
+        <input class="absolute" type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.energie.prolonger"
+        value="{{this.impulsions.guerre.energie.porteur}}"
         min="0"
          />
     </label>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-        <input class="absolute" type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.energie.porteur" 
-        value="{{this.impulsions.guerre.energie.porteur}}" 
+        <input class="absolute" type="number" name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.energie.porteur"
+        value="{{this.impulsions.guerre.energie.porteur}}"
         min="0"
          />
     </label>
@@ -277,7 +277,7 @@
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.warlord.impulsions.guerre.duree"
-        data-capacite="warlord" data-type="dureeGuerre" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeGuerre}}px;" 
+        data-capacite="warlord" data-type="dureeGuerre" data-min="50"  data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.dureeGuerre}}px;"
         >{{this.impulsions.guerre.duree}}</textarea>
     </label>
 </div>

--- a/templates/items/armures/evolutions/watchtower.html
+++ b/templates/items/armures/evolutions/watchtower.html
@@ -1,12 +1,12 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WATCHTOWER.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.watchtower.energie" 
-        value="{{this.energie}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.watchtower.energie"
+        value="{{this.energie}}"
         min="0"
          />
     </label>
@@ -24,7 +24,7 @@
     <label class="shortspan">
         <span>{{localize "KNIGHT.DUREE.Label"}}</span>
         <textarea name="system.evolutions.liste.{{key}}.capacites.watchtower.duree"
-        data-capacite="watchtower" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;" 
+        data-capacite="watchtower" data-type="duree" data-min="50" data-evolution="true" data-key="{{key}}" style="height:{{this.textarea.duree}}px;"
         >{{this.duree}}</textarea>
     </label>
 </div>

--- a/templates/items/armures/evolutions/windtalker.html
+++ b/templates/items/armures/evolutions/windtalker.html
@@ -1,18 +1,18 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WINDTALKER.Label"}}
     </h4>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.windtalker.flux" value="{{this.flux}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.windtalker.flux" value="{{this.flux}}"
+
         />
     </label>
     <label class="shortspan">
         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.windtalker.energie" value="{{this.energie}}" 
-        
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.windtalker.energie" value="{{this.energie}}"
+
         />
     </label>
     <label class="shortspan">

--- a/templates/items/armures/evolutions/zen.html
+++ b/templates/items/armures/evolutions/zen.html
@@ -1,13 +1,13 @@
 <div class="data">
-    <h4 class="title">
+    <h4 class="title js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ZEN.Label"}}
     </h4>
     <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ZEN.Caracteristiques"}}</h4>
     <label class="longspan">
         <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ZEN.Difficulte"}}</span>
-        <input type="number" name="system.evolutions.liste.{{key}}.capacites.zen.difficulte" 
-        value="{{this.difficulte}}" 
+        <input type="number" name="system.evolutions.liste.{{key}}.capacites.zen.difficulte"
+        value="{{this.difficulte}}"
         min="0"
             />
     </label>
@@ -15,7 +15,7 @@
         <div class="aspect">
             <h4 class="separation">{{getAspect aspect}}</h4>
             {{#each key.caracteristiques  as | keyCarac caracteristique|}}
-                <button type="action" 
+                <button type="action"
                 data-type="zen" data-caracteristique="true" data-key="{{../../key}}" data-aspect="{{aspect}}" data-name="{{caracteristique}}" data-value="{{keyCarac.value}}"
                 class="{{#if keyCarac.value}}selected{{/if}}">{{getCarac caracteristique}}</button>
             {{/each}}

--- a/templates/items/armures/special/apeiron.html
+++ b/templates/items/armures/special/apeiron.html
@@ -1,6 +1,6 @@
 
 <div class="apeiron">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.APEIRON.Label"}}
         <div>
@@ -24,13 +24,13 @@
         <div class="data">
             <label class="longspan">
                 <span>{{localize "KNIGHT.BONUS.Espoir"}}</span>
-                <input type="number" name="system.special.selected.apeiron.espoir.bonus" min="0" value="{{this.espoir.bonus}}" 
+                <input type="number" name="system.special.selected.apeiron.espoir.bonus" min="0" value="{{this.espoir.bonus}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.REDUCTION.Espoir"}}</span>
-                <input type="number" name="system.special.selected.apeiron.espoir.reduction.value" min="0" value="{{this.espoir.reduction.value}}" 
+                <input type="number" name="system.special.selected.apeiron.espoir.reduction.value" min="0" value="{{this.espoir.reduction.value}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armures/special/contrecoups.html
+++ b/templates/items/armures/special/contrecoups.html
@@ -1,6 +1,6 @@
 
 <div class="contrecoups">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.CONTRECOUPS.Label"}}
         <div>
@@ -57,7 +57,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                     {{/select}}
                 </select>
                 <select name="system.special.selected.contrecoups.jet.c2" {{#if this.softlock}}disabled{{/if}}>
@@ -69,7 +69,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                     {{/select}}
                 </select>
             </div>

--- a/templates/items/armures/special/impregnation.html
+++ b/templates/items/armures/special/impregnation.html
@@ -1,5 +1,5 @@
 <div class="impregnation">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.IMPREGNATION.Label"}}
         <div>
@@ -32,7 +32,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                     {{/select}}
                 </select>
                 <select name="system.special.selected.impregnation.jets.c2a" {{#if this.softlock}}disabled{{/if}}>
@@ -44,7 +44,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                     {{/select}}
                 </select>
             </div>
@@ -58,7 +58,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                     {{/select}}
                 </select>
                 <select name="system.special.selected.impregnation.jets.c2b" {{#if this.softlock}}disabled{{/if}}>
@@ -70,7 +70,7 @@
                                     <option value="{{carac}}">{{getCarac carac}}</option>
                                 {{/each}}
                             </optgroup>
-                        {{/each}}                    
+                        {{/each}}
                     {{/select}}
                 </select>
             </div>

--- a/templates/items/armures/special/lenteetlourde.html
+++ b/templates/items/armures/special/lenteetlourde.html
@@ -1,5 +1,5 @@
 <div class="lenteetlourde">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.LENTEETLOURDE.Label"}}
         <div>

--- a/templates/items/armures/special/personnalise.html
+++ b/templates/items/armures/special/personnalise.html
@@ -1,5 +1,5 @@
 <div class="personnalise">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PERSONNALISE.Label"}}
         <div>

--- a/templates/items/armures/special/plusespoir.html
+++ b/templates/items/armures/special/plusespoir.html
@@ -1,5 +1,5 @@
 <div class="plusespoir">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PLUSESPOIR.Label"}}
         <div>
@@ -23,8 +23,8 @@
         <div class="data">
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PLUSESPOIR.ESPOIR.Label"}}</span>
-                <input type="number" name="system.special.selected.plusespoir.espoir.base" 
-                    value="{{this.espoir.base}}" 
+                <input type="number" name="system.special.selected.plusespoir.espoir.base"
+                    value="{{this.espoir.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
             </label>

--- a/templates/items/armures/special/porteurlumiere.html
+++ b/templates/items/armures/special/porteurlumiere.html
@@ -1,6 +1,6 @@
 
 <div class="porteurlumiere">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.PORTEURLUMIERE.Label"}}
         <div>

--- a/templates/items/armures/special/recolteflux.html
+++ b/templates/items/armures/special/recolteflux.html
@@ -1,5 +1,5 @@
 <div class="recolteflux">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.Label"}}
         <div>
@@ -24,15 +24,15 @@
             <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXHORSCONFLIT.Label"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXHORSCONFLIT.FluxParCreature"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.horsconflit.base" 
-                value="{{this.horsconflit.base}}" 
+                <input type="number" name="system.special.selected.recolteflux.horsconflit.base"
+                value="{{this.horsconflit.base}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.AUTRE.Limite"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.horsconflit.limite" 
-                value="{{this.horsconflit.limite}}" 
+                <input type="number" name="system.special.selected.recolteflux.horsconflit.limite"
+                value="{{this.horsconflit.limite}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -55,36 +55,36 @@
             <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.Label"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.DebutConflit"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.base" 
-                value="{{this.conflit.base}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.base"
+                value="{{this.conflit.base}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.ParTour"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.tour" 
-                value="{{this.conflit.tour}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.tour"
+                value="{{this.conflit.tour}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.ParHostile"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.hostile" 
-                value="{{this.conflit.hostile}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.hostile"
+                value="{{this.conflit.hostile}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.ParSalopard"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.salopard" 
-                value="{{this.conflit.salopard}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.salopard"
+                value="{{this.conflit.salopard}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.ParPatron"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.patron" 
-                value="{{this.conflit.patron}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.patron"
+                value="{{this.conflit.patron}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>

--- a/templates/items/armuresLegende/capacites/changeling.html
+++ b/templates/items/armuresLegende/capacites/changeling.html
@@ -1,5 +1,5 @@
 <div class="changeling">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.Label"}}
         <div>
@@ -24,29 +24,29 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.Personnelle"}}</span>
-                <input type="number" name="system.capacites.selected.changeling.energie.personnel" 
-                value="{{this.energie.personnel}}" 
+                <input type="number" name="system.capacites.selected.changeling.energie.personnel"
+                value="{{this.energie.personnel}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.Etendue"}}</span>
-                <input type="number" name="system.capacites.selected.changeling.energie.etendue" 
-                value="{{this.energie.etendue}}" 
+                <input type="number" name="system.capacites.selected.changeling.energie.etendue"
+                value="{{this.energie.etendue}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.ENERGIE.ParFauxEtres"}}</span>
-                <input type="number" name="system.capacites.selected.changeling.energie.fauxEtre.value" 
-                value="{{this.energie.fauxEtre.value}}" 
+                <input type="number" name="system.capacites.selected.changeling.energie.fauxEtre.value"
+                value="{{this.energie.fauxEtre.value}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan separation">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.CHANGELING.FauxEtresMax"}}</span>
-                <input type="number" name="system.capacites.selected.changeling.energie.fauxEtre.max" 
-                value="{{this.energie.fauxEtre.max}}" 
+                <input type="number" name="system.capacites.selected.changeling.energie.fauxEtre.max"
+                value="{{this.energie.fauxEtre.max}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -66,14 +66,14 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.changeling.duree" 
-                data-capacite="changeling" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.changeling.duree"
+                data-capacite="changeling" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.PORTEE.Label"}}</span>
-                <textarea name="system.capacites.selected.changeling.portee" 
-                    data-capacite="changeling" data-type="portee" data-min="50" style="height:{{this.textarea.portee}}px;" 
+                <textarea name="system.capacites.selected.changeling.portee"
+                    data-capacite="changeling" data-type="portee" data-min="50" style="height:{{this.textarea.portee}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.portee}}</textarea>
             </label>
         </div>

--- a/templates/items/armuresLegende/capacites/companions.html
+++ b/templates/items/armuresLegende/capacites/companions.html
@@ -1,5 +1,5 @@
 <div class="companions">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Label"}}
         <div>
@@ -24,15 +24,15 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.ENERGIE.Base"}}</span>
-                <input type="number" name="system.capacites.selected.companions.energie.base" 
-                value="{{this.energie.base}}" 
+                <input type="number" name="system.capacites.selected.companions.energie.base"
+                value="{{this.energie.base}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.ENERGIE.Prolonger"}}</span>
-                <input type="number" name="system.capacites.selected.companions.energie.prolonger" 
-                value="{{this.energie.prolonger}}" 
+                <input type="number" name="system.capacites.selected.companions.energie.prolonger"
+                value="{{this.energie.prolonger}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -57,15 +57,15 @@
             <h4>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.Label"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.Pointgloiredepart"}}</span>
-                <input type="number" name="system.capacites.selected.companions.lion.PG" 
-                value="{{this.lion.PG}}" 
+                <input type="number" name="system.capacites.selected.companions.lion.PG"
+                value="{{this.lion.PG}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
         </div>
 
         <div class="lion">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.LION.Label"}}
             </h4>
@@ -75,8 +75,8 @@
                         <h5>{{getAspect aspect}}</h5>
                         <label>
                             <span>{{localize "KNIGHT.ASPECTS.Aspect"}}</span>
-                            <input type="number" name="system.capacites.selected.companions.lion.aspects.{{aspect}}.value" 
-                            value="{{key.value}}" 
+                            <input type="number" name="system.capacites.selected.companions.lion.aspects.{{aspect}}.value"
+                            value="{{key.value}}"
                             min="0"
                             {{#if ../this.softlock}}disabled{{/if}} />
                         </label>
@@ -104,43 +104,43 @@
             <div class="derives" style="display:none;">
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Defense"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.lion.defense.base" 
-                    value="{{this.lion.defense.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.lion.defense.base"
+                    value="{{this.lion.defense.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Reaction"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.lion.reaction.base" 
-                    value="{{this.lion.reaction.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.lion.reaction.base"
+                    value="{{this.lion.reaction.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
                     <div class="block">
-                        <input type="number" name="system.capacites.selected.companions.lion.initiative.value" 
-                        value="{{this.lion.initiative.value}}" 
+                        <input type="number" name="system.capacites.selected.companions.lion.initiative.value"
+                        value="{{this.lion.initiative.value}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                        <input type="number" name="system.capacites.selected.companions.lion.initiative.fixe" 
+                        <input type="number" name="system.capacites.selected.companions.lion.initiative.fixe"
                         value="{{this.lion.initiative.fixe}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
-                    </div>                    
+                    </div>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Armure"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.lion.armure.base" 
-                    value="{{this.lion.armure.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.lion.armure.base"
+                    value="{{this.lion.armure.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.ChampDeForce"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.lion.champDeForce.base" 
-                    value="{{this.lion.champDeForce.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.lion.champDeForce.base"
+                    value="{{this.lion.champDeForce.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
@@ -156,7 +156,7 @@
                 {{#each this.lion.armes.contact as | key arme|}}
                     <div class="line {{#unless @first}} separation {{/unless}}">
                         <div class="label">
-                            <input type="text" name="system.capacites.selected.companions.lion.armes.contact.{{arme}}.label" value="{{key.label}}" 
+                            <input type="text" name="system.capacites.selected.companions.lion.armes.contact.{{arme}}.label" value="{{key.label}}"
                             {{#if ../this.softlock}}disabled{{/if}}
                             />
                         </div>
@@ -208,7 +208,7 @@
         </div>
 
         <div class="wolf">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.Label"}}
             </h4>
@@ -218,8 +218,8 @@
                         <h5>{{getAspect aspect}}</h5>
                         <label>
                             <span>{{localize "KNIGHT.ASPECTS.Aspect"}}</span>
-                            <input type="number" name="system.capacites.selected.companions.wolf.aspects.{{aspect}}.value" 
-                            value="{{key.value}}" 
+                            <input type="number" name="system.capacites.selected.companions.wolf.aspects.{{aspect}}.value"
+                            value="{{key.value}}"
                             min="0"
                             {{#if ../this.softlock}}disabled{{/if}} />
                         </label>
@@ -247,43 +247,43 @@
             <div class="derives" style="display:none;">
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Defense"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.wolf.defense.base" 
-                    value="{{this.wolf.defense.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.wolf.defense.base"
+                    value="{{this.wolf.defense.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Reaction"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.wolf.reaction.base" 
-                    value="{{this.wolf.reaction.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.wolf.reaction.base"
+                    value="{{this.wolf.reaction.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
                     <div class="block">
-                        <input type="number" name="system.capacites.selected.companions.wolf.initiative.value" 
-                        value="{{this.wolf.initiative.value}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.initiative.value"
+                        value="{{this.wolf.initiative.value}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.initiative.fixe" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.initiative.fixe"
                         value="{{this.wolf.initiative.fixe}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
-                    </div>                    
+                    </div>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Armure"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.wolf.armure.base" 
-                    value="{{this.wolf.armure.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.wolf.armure.base"
+                    value="{{this.wolf.armure.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.ChampDeForce"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.wolf.champDeForce.base" 
-                    value="{{this.wolf.champDeForce.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.wolf.champDeForce.base"
+                    value="{{this.wolf.champDeForce.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
@@ -299,7 +299,7 @@
                 {{#each this.wolf.armes.contact as | key arme|}}
                     <div class="line {{#unless @first}} separation {{/unless}}">
                         <div class="label">
-                            <input type="text" name="system.capacites.selected.companions.wolf.armes.contact.{{arme}}.label" value="{{key.label}}" 
+                            <input type="text" name="system.capacites.selected.companions.wolf.armes.contact.{{arme}}.label" value="{{key.label}}"
                             {{#if ../this.softlock}}disabled{{/if}}
                             />
                         </div>
@@ -357,15 +357,15 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.labor.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.labor.energie" 
-                        value="{{this.wolf.configurations.labor.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.labor.energie"
+                        value="{{this.wolf.configurations.labor.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.labor.bonus.roll" 
-                        value="{{this.wolf.configurations.labor.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.labor.bonus.roll"
+                        value="{{this.wolf.configurations.labor.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
@@ -379,29 +379,29 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.medic.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.energie" 
-                        value="{{this.wolf.configurations.medic.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.energie"
+                        value="{{this.wolf.configurations.medic.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.bonus.roll" 
-                        value="{{this.wolf.configurations.medic.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.bonus.roll"
+                        value="{{this.wolf.configurations.medic.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
                     </label>
                     <label class="longspanWSante">
                         <span class="label">{{localize "KNIGHT.BONUS.Soins"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.bonus.soins" 
-                        value="{{this.wolf.configurations.medic.bonus.soins}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.medic.bonus.soins"
+                        value="{{this.wolf.configurations.medic.bonus.soins}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="sante">{{localize "KNIGHT.AUTRE.PointSante-short"}}</span>
                     </label>
                 </div>
-                
+
                 <div class="configuration">
                     <h6>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.WOLF.CONFIGURATIONS.TECH.Label"}}</h6>
                     <textarea data-capacite="companions" data-type="tech" data-min="50" style="height:{{this.textarea.tech}}px;"
@@ -409,23 +409,23 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.tech.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.energie" 
-                        value="{{this.wolf.configurations.tech.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.energie"
+                        value="{{this.wolf.configurations.tech.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.bonus.roll" 
-                        value="{{this.wolf.configurations.tech.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.bonus.roll"
+                        value="{{this.wolf.configurations.tech.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
                     </label>
                     <label class="longspanWArmure">
                         <span class="label">{{localize "KNIGHT.BONUS.Reparation"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.bonus.reparation" 
-                        value="{{this.wolf.configurations.tech.bonus.reparation}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.tech.bonus.reparation"
+                        value="{{this.wolf.configurations.tech.bonus.reparation}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="armure">{{localize "KNIGHT.AUTRE.PointArmure-short"}}</span>
@@ -439,15 +439,15 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.recon.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.recon.energie" 
-                        value="{{this.wolf.configurations.recon.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.recon.energie"
+                        value="{{this.wolf.configurations.recon.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.recon.bonus.roll" 
-                        value="{{this.wolf.configurations.recon.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.recon.bonus.roll"
+                        value="{{this.wolf.configurations.recon.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
@@ -461,31 +461,31 @@
                     {{#if this.softlock}}disabled{{/if}}>{{this.wolf.configurations.fighter.description}}</textarea>
                     <label class="longspan">
                         <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.energie" 
-                        value="{{this.wolf.configurations.fighter.energie}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.energie"
+                        value="{{this.wolf.configurations.fighter.energie}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                     </label>
                     <label class="longspanWDice">
                         <span class="label">{{localize "KNIGHT.BONUS.Jet"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.bonus.roll" 
-                        value="{{this.wolf.configurations.fighter.bonus.roll}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.bonus.roll"
+                        value="{{this.wolf.configurations.fighter.bonus.roll}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="dice">{{localize "KNIGHT.JETS.Des-short"}}</span>
                     </label>
                     <label class="longspanWDegats">
                         <span class="label">{{localize "KNIGHT.AUTRE.Degats"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.degats" 
-                        value="{{this.wolf.configurations.fighter.degats}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.degats"
+                        value="{{this.wolf.configurations.fighter.degats}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="degats">{{localize "KNIGHT.JETS.Des-short"}}6</span>
                     </label>
                     <label class="longspanWViolence">
                         <span class="label">{{localize "KNIGHT.AUTRE.Violence"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.Companion"}}</span>
-                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.violence" 
-                        value="{{this.wolf.configurations.fighter.violence}}" 
+                        <input type="number" name="system.capacites.selected.companions.wolf.configurations.fighter.violence"
+                        value="{{this.wolf.configurations.fighter.violence}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span class="violence">{{localize "KNIGHT.JETS.Des-short"}}6</span>
@@ -508,7 +508,7 @@
         </div>
 
         <div class="crow">
-            <h4 class="title header">
+            <h4 class="title header js-toggler">
                 <i class="far fa-plus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.COMPANIONS.CROW.Label"}}
             </h4>
@@ -518,8 +518,8 @@
                         <h5>{{getAspect aspect}}</h5>
                         <label>
                             <span>{{localize "KNIGHT.ASPECTS.Aspect"}}</span>
-                            <input type="number" name="system.capacites.selected.companions.crow.aspects.{{aspect}}.value" 
-                            value="{{key.value}}" 
+                            <input type="number" name="system.capacites.selected.companions.crow.aspects.{{aspect}}.value"
+                            value="{{key.value}}"
                             min="0"
                             {{#if ../this.softlock}}disabled{{/if}} />
                         </label>
@@ -529,43 +529,43 @@
             <div class="derives" style="display:none;">
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Defense"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.defense.base" 
-                    value="{{this.crow.defense.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.defense.base"
+                    value="{{this.crow.defense.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Reaction"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.reaction.base" 
-                    value="{{this.crow.reaction.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.reaction.base"
+                    value="{{this.crow.reaction.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Initiative"}}</h5>
                     <div class="block">
-                        <input type="number" name="system.capacites.selected.companions.crow.initiative.value" 
-                        value="{{this.crow.initiative.value}}" 
+                        <input type="number" name="system.capacites.selected.companions.crow.initiative.value"
+                        value="{{this.crow.initiative.value}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
                         <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                        <input type="number" name="system.capacites.selected.companions.crow.initiative.fixe" 
+                        <input type="number" name="system.capacites.selected.companions.crow.initiative.fixe"
                         value="{{this.crow.initiative.fixe}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
-                    </div>                    
+                    </div>
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.Cohesion"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.cohesion.base" 
-                    value="{{this.crow.cohesion.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.cohesion.base"
+                    value="{{this.crow.cohesion.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
                 <div class="col">
                     <h5>{{localize "KNIGHT.LATERAL.ChampDeForce"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.champDeForce.base" 
-                    value="{{this.crow.champDeForce.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.champDeForce.base"
+                    value="{{this.crow.champDeForce.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>
@@ -573,8 +573,8 @@
             <div class="debordement" style="display:none;">
                 <div class="col">
                     <h5>{{localize "KNIGHT.AUTRE.Debordement"}}</h5>
-                    <input type="number" name="system.capacites.selected.companions.crow.debordement.base" 
-                    value="{{this.crow.debordement.base}}" 
+                    <input type="number" name="system.capacites.selected.companions.crow.debordement.base"
+                    value="{{this.crow.debordement.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </div>

--- a/templates/items/armuresLegende/capacites/discord.html
+++ b/templates/items/armuresLegende/capacites/discord.html
@@ -1,6 +1,6 @@
 
 <div class="discord">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Label"}}
         <div>
@@ -25,13 +25,13 @@
             <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Tour"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-                <input type="number" name="system.capacites.selected.discord.tour.flux" value="{{this.tour.flux}}" 
+                <input type="number" name="system.capacites.selected.discord.tour.flux" value="{{this.tour.flux}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.discord.tour.energie" value="{{this.tour.energie}}" 
+                <input type="number" name="system.capacites.selected.discord.tour.energie" value="{{this.tour.energie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -56,13 +56,13 @@
             <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.DISCORD.Scene"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-                <input type="number" name="system.capacites.selected.discord.scene.flux" value="{{this.scene.flux}}" 
+                <input type="number" name="system.capacites.selected.discord.scene.flux" value="{{this.scene.flux}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.discord.scene.energie" value="{{this.scene.energie}}" 
+                <input type="number" name="system.capacites.selected.discord.scene.energie" value="{{this.scene.energie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -86,19 +86,19 @@
         <div class="data fullWidth">
             <label class="doubleLine">
                 <span>{{localize "KNIGHT.MALUS.Actions"}}</span>
-                <input type="number" name="system.capacites.selected.discord.malus.actions" value="{{this.malus.actions}}" 
+                <input type="number" name="system.capacites.selected.discord.malus.actions" value="{{this.malus.actions}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="doubleLine">
                 <span>{{localize "KNIGHT.MALUS.Reaction"}}</span>
-                <input type="number" name="system.capacites.selected.discord.malus.reaction" value="{{this.malus.reaction}}" 
+                <input type="number" name="system.capacites.selected.discord.malus.reaction" value="{{this.malus.reaction}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="doubleLine">
                 <span>{{localize "KNIGHT.MALUS.Defense"}}</span>
-                <input type="number" name="system.capacites.selected.discord.malus.defense" value="{{this.malus.defense}}" 
+                <input type="number" name="system.capacites.selected.discord.malus.defense" value="{{this.malus.defense}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armuresLegende/capacites/falcon.html
+++ b/templates/items/armuresLegende/capacites/falcon.html
@@ -1,6 +1,6 @@
 
 <div class="falcon">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.FALCON.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.falcon.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.falcon.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -42,8 +42,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.falcon.duree" 
-                data-capacite="falcon" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.falcon.duree"
+                data-capacite="falcon" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armuresLegende/capacites/ghost.html
+++ b/templates/items/armuresLegende/capacites/ghost.html
@@ -1,6 +1,6 @@
 
 <div class="ghost">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.Label"}}
         <div>
@@ -25,15 +25,15 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.ENERGIE.Tour"}}</span>
-                <input type="number" name="system.capacites.selected.ghost.energie.tour" 
-                value="{{this.energie.tour}}" 
+                <input type="number" name="system.capacites.selected.ghost.energie.tour"
+                value="{{this.energie.tour}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.ENERGIE.Minute"}}</span>
-                <input type="number" name="system.capacites.selected.ghost.energie.minute" 
-                value="{{this.energie.minute}}" 
+                <input type="number" name="system.capacites.selected.ghost.energie.minute"
+                value="{{this.energie.minute}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -50,8 +50,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.ghost.duree" 
-                data-capacite="ghost" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.ghost.duree"
+                data-capacite="ghost" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
             <button type="action" class="{{#unless this.softlock}}notDisabled{{/unless}} {{#if this.interruption.actif}}selected{{/if}}"

--- a/templates/items/armuresLegende/capacites/goliath.html
+++ b/templates/items/armuresLegende/capacites/goliath.html
@@ -1,6 +1,6 @@
 
 <div class="goliath">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GOLIATH.Label"}}
         <div>

--- a/templates/items/armuresLegende/capacites/mechanic.html
+++ b/templates/items/armuresLegende/capacites/mechanic.html
@@ -1,6 +1,6 @@
 
 <div class="mechanic">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Label"}}
         <div>
@@ -25,7 +25,7 @@
             <h4>{{localize "KNIGHT.AUTRE.Contact"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.mechanic.energie.contact" value="{{this.energie.contact}}" 
+                <input type="number" name="system.capacites.selected.mechanic.energie.contact" value="{{this.energie.contact}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -43,19 +43,19 @@
             <div class="shortspan triple">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Reparation"}}</span>
                 <label>
-                    <input type="number" name="system.capacites.selected.mechanic.reparation.contact.dice" value="{{this.reparation.contact.dice}}" 
+                    <input type="number" name="system.capacites.selected.mechanic.reparation.contact.dice" value="{{this.reparation.contact.dice}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                     <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.mechanic.reparation.contact.fixe" value="{{this.reparation.contact.fixe}}" 
+                    <input type="number" name="system.capacites.selected.mechanic.reparation.contact.fixe" value="{{this.reparation.contact.fixe}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
             </div>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.mechanic.reparation.contact.duree" 
-                data-capacite="mechanic" data-type="dureeContact" data-min="50" style="height:{{this.textarea.dureeContact}}px;" 
+                <textarea name="system.capacites.selected.mechanic.reparation.contact.duree"
+                data-capacite="mechanic" data-type="dureeContact" data-min="50" style="height:{{this.textarea.dureeContact}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.reparation.contact.duree}}</textarea>
             </label>
         </div>
@@ -64,7 +64,7 @@
             <h4>{{localize "KNIGHT.AUTRE.Distance"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.mechanic.energie.distance" value="{{this.energie.distance}}" 
+                <input type="number" name="system.capacites.selected.mechanic.energie.distance" value="{{this.energie.distance}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -82,19 +82,19 @@
             <div class="shortspan triple">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.MECHANIC.Reparation"}}</span>
                 <label>
-                    <input type="number" name="system.capacites.selected.mechanic.reparation.distance.dice" value="{{this.reparation.distance.dice}}" 
+                    <input type="number" name="system.capacites.selected.mechanic.reparation.distance.dice" value="{{this.reparation.distance.dice}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                     <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.mechanic.reparation.distance.fixe" value="{{this.reparation.distance.fixe}}" 
+                    <input type="number" name="system.capacites.selected.mechanic.reparation.distance.fixe" value="{{this.reparation.distance.fixe}}"
                     {{#if this.softlock}}disabled{{/if}}
                     />
                 </label>
             </div>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.mechanic.reparation.distance.duree" 
-                data-capacite="mechanic" data-type="dureeDistance" data-min="50" style="height:{{this.textarea.dureeDistance}}px;" 
+                <textarea name="system.capacites.selected.mechanic.reparation.distance.duree"
+                data-capacite="mechanic" data-type="dureeDistance" data-min="50" style="height:{{this.textarea.dureeDistance}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.reparation.distance.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armuresLegende/capacites/nanoc.html
+++ b/templates/items/armuresLegende/capacites/nanoc.html
@@ -1,5 +1,5 @@
 <div class="nanoc">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.Label"}}
         <div>
@@ -24,22 +24,22 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ObjetBase"}}</span>
-                <input type="number" name="system.capacites.selected.nanoc.energie.base" 
-                value="{{this.energie.base}}" 
+                <input type="number" name="system.capacites.selected.nanoc.energie.base"
+                value="{{this.energie.base}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}}/>
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ObjetDetaille"}}</span>
-                <input type="number" name="system.capacites.selected.nanoc.energie.detaille" 
-                value="{{this.energie.detaille}}" 
+                <input type="number" name="system.capacites.selected.nanoc.energie.detaille"
+                value="{{this.energie.detaille}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}}/>
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.AUTRE.Prolonger"}} / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.NANOC.ParMinute"}}</span>
-                <input type="number" name="system.capacites.selected.nanoc.energie.prolonger" 
-                value="{{this.energie.prolonger}}" 
+                <input type="number" name="system.capacites.selected.nanoc.energie.prolonger"
+                value="{{this.energie.prolonger}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}}/>
             </label>
@@ -58,7 +58,7 @@
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                 <textarea name="system.capacites.selected.nanoc.duree"
-                data-capacite="nanoc" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                data-capacite="nanoc" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armuresLegende/capacites/oriflamme.html
+++ b/templates/items/armuresLegende/capacites/oriflamme.html
@@ -1,6 +1,6 @@
 
 <div class="oriflamme">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.ORIFLAMME.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.oriflamme.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.oriflamme.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -43,8 +43,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.oriflamme.duree" 
-                data-capacite="oriflamme" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"  
+                <textarea name="system.capacites.selected.oriflamme.duree"
+                data-capacite="oriflamme" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
             <label class="shortspan">
@@ -65,13 +65,13 @@
             <div class="double">
                 <span>{{localize "KNIGHT.AUTRE.Degats"}}</span>
                 <label>
-                    <input type="number" name="system.capacites.selected.oriflamme.degats.dice" 
-                    value="{{this.degats.dice}}" 
+                    <input type="number" name="system.capacites.selected.oriflamme.degats.dice"
+                    value="{{this.degats.dice}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                     <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.oriflamme.degats.fixe" 
-                    value="{{this.degats.fixe}}" 
+                    <input type="number" name="system.capacites.selected.oriflamme.degats.fixe"
+                    value="{{this.degats.fixe}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -79,13 +79,13 @@
             <div class="double">
                 <span>{{localize "KNIGHT.AUTRE.Violence"}}</span>
                 <label>
-                    <input type="number" name="system.capacites.selected.oriflamme.violence.dice" 
-                    value="{{this.violence.dice}}" 
+                    <input type="number" name="system.capacites.selected.oriflamme.violence.dice"
+                    value="{{this.violence.dice}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                     <span>{{localize "KNIGHT.JETS.Des-short"}}6+</span>
-                    <input type="number" name="system.capacites.selected.oriflamme.violence.fixe" 
-                    value="{{this.violence.fixe}}" 
+                    <input type="number" name="system.capacites.selected.oriflamme.violence.fixe"
+                    value="{{this.violence.fixe}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>

--- a/templates/items/armuresLegende/capacites/personnalise.html
+++ b/templates/items/armuresLegende/capacites/personnalise.html
@@ -1,5 +1,5 @@
 <div class="personnalise">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PERSONNALISE.Label"}}
         <div>

--- a/templates/items/armuresLegende/capacites/puppet.html
+++ b/templates/items/armuresLegende/capacites/puppet.html
@@ -1,6 +1,6 @@
 
 <div class="puppet">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Label"}}
         <div>
@@ -25,19 +25,19 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Ordre"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.energie.ordre" value="{{this.energie.ordre}}" 
+                <input type="number" name="system.capacites.selected.puppet.energie.ordre" value="{{this.energie.ordre}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Creature"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.energie.supplementaire" value="{{this.energie.supplementaire}}" 
+                <input type="number" name="system.capacites.selected.puppet.energie.supplementaire" value="{{this.energie.supplementaire}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Prolonger"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.energie.prolonger" value="{{this.energie.prolonger}}" 
+                <input type="number" name="system.capacites.selected.puppet.energie.prolonger" value="{{this.energie.prolonger}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -62,25 +62,25 @@
             <h4>{{localize "KNIGHT.LATERAL.Flux"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Ordre"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.flux.ordre" value="{{this.flux.ordre}}" 
+                <input type="number" name="system.capacites.selected.puppet.flux.ordre" value="{{this.flux.ordre}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Creature"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.flux.supplementaire" value="{{this.flux.supplementaire}}" 
+                <input type="number" name="system.capacites.selected.puppet.flux.supplementaire" value="{{this.flux.supplementaire}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Prolonger"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.flux.prolonger" value="{{this.flux.prolonger}}" 
+                <input type="number" name="system.capacites.selected.puppet.flux.prolonger" value="{{this.flux.prolonger}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan separation">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.PUPPET.Max"}}</span>
-                <input type="number" name="system.capacites.selected.puppet.creatures" value="{{this.creatures}}" 
+                <input type="number" name="system.capacites.selected.puppet.creatures" value="{{this.creatures}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armuresLegende/capacites/record.html
+++ b/templates/items/armuresLegende/capacites/record.html
@@ -1,6 +1,6 @@
 
 <div class="record">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.RECORD.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.record.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.record.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -42,8 +42,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.record.duree" 
-                data-capacite="record" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.record.duree"
+                data-capacite="record" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armuresLegende/capacites/rewind.html
+++ b/templates/items/armuresLegende/capacites/rewind.html
@@ -1,6 +1,6 @@
 
 <div class="rewind">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.REWIND.Label"}}
         <div>
@@ -24,8 +24,8 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.rewind.energie" 
-                value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.rewind.energie"
+                value="{{this.energie}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -42,8 +42,8 @@
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
-                <textarea name="system.capacites.selected.rewind.duree" 
-                data-capacite="rewind" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                <textarea name="system.capacites.selected.rewind.duree"
+                data-capacite="rewind" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armuresLegende/capacites/shrine.html
+++ b/templates/items/armuresLegende/capacites/shrine.html
@@ -1,6 +1,6 @@
 
 <div class="shrine">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.Label"}}
         <div>
@@ -25,13 +25,13 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Personnel"}}</span>
-                <input type="number" name="system.capacites.selected.shrine.energie.personnel" value="{{this.energie.personnel}}" 
+                <input type="number" name="system.capacites.selected.shrine.energie.personnel" value="{{this.energie.personnel}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.SHRINE.ENERGIE.Distance"}}</span>
-                <input type="number" name="system.capacites.selected.shrine.energie.distance" value="{{this.energie.distance}}" 
+                <input type="number" name="system.capacites.selected.shrine.energie.distance" value="{{this.energie.distance}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armuresLegende/capacites/totem.html
+++ b/templates/items/armuresLegende/capacites/totem.html
@@ -1,6 +1,6 @@
 
 <div class="totem">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Label"}}
         <div>
@@ -26,8 +26,8 @@
             <div class="double">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.ENERGIE.Matérialiser"}}</span>
                 <label class="block">
-                    <input type="number" name="system.capacites.selected.totem.energie.base" 
-                    value="{{this.energie.base}}" 
+                    <input type="number" name="system.capacites.selected.totem.energie.base"
+                    value="{{this.energie.base}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                     <span> / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Totem"}}</span>
@@ -36,8 +36,8 @@
             <div class="double">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.ENERGIE.Prolonger"}}</span>
                 <label class="block">
-                        <input type="number" name="system.capacites.selected.totem.energie.prolonger" 
-                    value="{{this.energie.prolonger}}" 
+                        <input type="number" name="system.capacites.selected.totem.energie.prolonger"
+                    value="{{this.energie.prolonger}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                     <span> / {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Totem"}}</span>
@@ -45,15 +45,15 @@
             </div>
             <label class="longspan separation">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TOTEM.Nombre"}}</span>
-                <input type="number" name="system.capacites.selected.totem.nombre" 
-                value="{{this.nombre}}" 
+                <input type="number" name="system.capacites.selected.totem.nombre"
+                value="{{this.nombre}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.AUTRE.GainImpregnation"}}</span>
-                <input type="number" name="system.capacites.selected.totem.impregnation" 
-                value="{{this.impregnation}}" 
+                <input type="number" name="system.capacites.selected.totem.impregnation"
+                value="{{this.impregnation}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>

--- a/templates/items/armuresLegende/capacites/type.html
+++ b/templates/items/armuresLegende/capacites/type.html
@@ -1,6 +1,6 @@
 
 <div class="type">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.Label"}}
         <div>
@@ -24,23 +24,23 @@
         <div class="data plainData">
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.TypesPossedes"}}</span>
-                <input type="number" name="system.capacites.selected.type.nbreType" 
-                value="{{this.nbreType}}" 
+                <input type="number" name="system.capacites.selected.type.nbreType"
+                value="{{this.nbreType}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <h4 class="separation">{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.ENERGIE.Tour"}}</span>
-                <input type="number" name="system.capacites.selected.type.energie.tour" 
-                value="{{this.energie.tour}}" 
+                <input type="number" name="system.capacites.selected.type.energie.tour"
+                value="{{this.energie.tour}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.TYPE.ENERGIE.Scene"}}</span>
-                <input type="number" name="system.capacites.selected.type.energie.scene" 
-                value="{{this.energie.scene}}" 
+                <input type="number" name="system.capacites.selected.type.energie.scene"
+                value="{{this.energie.scene}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -58,7 +58,7 @@
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                 <textarea name="system.capacites.selected.type.duree"
-                data-capacite="type" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                data-capacite="type" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>
@@ -70,8 +70,8 @@
                 {{#each key.liste as | tKey dType|}}
                     <label class="doubleLine">
                         <span>{{tKey.label}}</span>
-                        <input type="number" name="system.capacites.selected.type.type.{{type}}.liste.{{dType}}.value" 
-                        value="{{this.value}}" 
+                        <input type="number" name="system.capacites.selected.type.type.{{type}}.liste.{{dType}}.value"
+                        value="{{this.value}}"
                         min="0"
                         {{#if ../../this.softlock}}disabled{{/if}} />
                     </label>

--- a/templates/items/armuresLegende/capacites/vision.html
+++ b/templates/items/armuresLegende/capacites/vision.html
@@ -1,6 +1,6 @@
 
 <div class="vision">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.VISION.Label"}}
         <div>
@@ -25,13 +25,13 @@
             <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.AUTRE.Minimum"}}</span>
-                <input type="text" name="system.capacites.selected.vision.energie.min" value="{{this.energie.min}}" 
+                <input type="text" name="system.capacites.selected.vision.energie.min" value="{{this.energie.min}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.AUTRE.Maximum"}}</span>
-                <input type="text" name="system.capacites.selected.vision.energie.max" value="{{this.energie.max}}" 
+                <input type="text" name="system.capacites.selected.vision.energie.max" value="{{this.energie.max}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
@@ -49,7 +49,7 @@
             <label class="shortspan">
                 <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                 <textarea name="system.capacites.selected.vision.duree"
-                data-capacite="vision" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;" 
+                data-capacite="vision" data-type="duree" data-min="50" style="height:{{this.textarea.duree}}px;"
                 {{#if this.softlock}}disabled{{/if}}>{{this.duree}}</textarea>
             </label>
         </div>

--- a/templates/items/armuresLegende/capacites/warlord.html
+++ b/templates/items/armuresLegende/capacites/warlord.html
@@ -1,5 +1,5 @@
 <div class="warlord">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.Label"}}
         <div>
@@ -24,8 +24,8 @@
             <div class="data">
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.NombresModes"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.selection" 
-                    value="{{this.impulsions.selection}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.selection"
+                    value="{{this.impulsions.selection}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -36,21 +36,21 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.BONUS.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.action.bonus.description"
-                    data-capacite="warlord" data-type="bonusAction" data-min="85" style="height:{{this.textarea.bonusAction}}px;" 
+                    data-capacite="warlord" data-type="bonusAction" data-min="85" style="height:{{this.textarea.bonusAction}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.action.bonus.description}}</textarea>
                 </label>
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.action.energie.allie" 
-                    value="{{this.impulsions.action.energie.allie}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.action.energie.allie"
+                    value="{{this.impulsions.action.energie.allie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.action.energie.porteur" 
-                    value="{{this.impulsions.action.energie.porteur}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.action.energie.porteur"
+                    value="{{this.impulsions.action.energie.porteur}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -68,7 +68,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.action.duree"
-                    data-capacite="warlord" data-type="dureeAction" data-min="50" style="height:{{this.textarea.dureeAction}}px;" 
+                    data-capacite="warlord" data-type="dureeAction" data-min="50" style="height:{{this.textarea.dureeAction}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.action.duree}}</textarea>
                 </label>
             </div>
@@ -77,7 +77,7 @@
                 <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.FORCE.Label"}}</h4>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.BONUS.ChampDeForce"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.force.bonus.champDeForce" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.force.bonus.champDeForce"
                     value="{{this.impulsions.force.bonus.champDeForce}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
@@ -85,22 +85,22 @@
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.force.energie.allie" 
-                    value="{{this.impulsions.force.energie.allie}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.force.energie.allie"
+                    value="{{this.impulsions.force.energie.allie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.force.energie.porteur" 
-                    value="{{this.impulsions.force.energie.porteur}}" 
+                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.force.energie.porteur"
+                    value="{{this.impulsions.force.energie.porteur}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.force.energie.prolonger" 
-                    value="{{this.impulsions.force.energie.prolonger}}" 
+                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.force.energie.prolonger"
+                    value="{{this.impulsions.force.energie.prolonger}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -118,7 +118,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.force.duree"
-                    data-capacite="warlord" data-type="dureeForce" data-min="50" style="height:{{this.textarea.dureeForce}}px;" 
+                    data-capacite="warlord" data-type="dureeForce" data-min="50" style="height:{{this.textarea.dureeForce}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.force.duree}}</textarea>
                 </label>
             </div>
@@ -128,22 +128,22 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.BONUS.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.energie.bonus.description"
-                    data-capacite="warlord" data-type="bonusEnergie" data-min="110" style="height:{{this.textarea.bonusEnergie}}px;" 
+                    data-capacite="warlord" data-type="bonusEnergie" data-min="110" style="height:{{this.textarea.bonusEnergie}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.energie.bonus.description}}</textarea>
                 </label>
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.AUTRE.Minimum"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.energie.energie.min" 
-                    value="{{this.impulsions.energie.energie.min}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.energie.energie.min"
+                    value="{{this.impulsions.energie.energie.min}}"
                     min="0"
                     max="{{this.impulsions.energie.energie.max}}"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.AUTRE.Maximum"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.energie.energie.max" 
-                    value="{{this.impulsions.energie.energie.max}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.energie.energie.max"
+                    value="{{this.impulsions.energie.energie.max}}"
                     min="{{this.impulsions.energie.energie.min}}"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -161,7 +161,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.energie.duree"
-                    data-capacite="warlord" data-type="dureeEnergie" data-min="50" style="height:{{this.textarea.dureeEnergie}}px;" 
+                    data-capacite="warlord" data-type="dureeEnergie" data-min="50" style="height:{{this.textarea.dureeEnergie}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.energie.duree}}</textarea>
                 </label>
             </div>
@@ -172,37 +172,37 @@
                 <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.ESQUIVE.Label"}}</h4>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.BONUS.Defense"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.bonus.defense" 
-                    value="{{this.impulsions.esquive.bonus.defense}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.bonus.defense"
+                    value="{{this.impulsions.esquive.bonus.defense}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.BONUS.Reaction"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.bonus.reaction" 
-                    value="{{this.impulsions.esquive.bonus.reaction}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.bonus.reaction"
+                    value="{{this.impulsions.esquive.bonus.reaction}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.allie" 
-                    value="{{this.impulsions.esquive.energie.allie}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.allie"
+                    value="{{this.impulsions.esquive.energie.allie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.porteur" 
-                    value="{{this.impulsions.esquive.energie.porteur}}" 
+                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.porteur"
+                    value="{{this.impulsions.esquive.energie.porteur}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.prolonger" 
-                    value="{{this.impulsions.esquive.energie.prolonger}}" 
+                    <input class="absolute"  type="number" name="system.capacites.selected.warlord.impulsions.esquive.energie.prolonger"
+                    value="{{this.impulsions.esquive.energie.prolonger}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -220,7 +220,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.esquive.duree"
-                    data-capacite="warlord" data-type="dureeEsquive" data-min="50" style="height:{{this.textarea.dureeEsquive}}px;" 
+                    data-capacite="warlord" data-type="dureeEsquive" data-min="50" style="height:{{this.textarea.dureeEsquive}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.esquive.duree}}</textarea>
                 </label>
             </div>
@@ -230,7 +230,7 @@
                 <div class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.BONUS.Degats"}}</span>
                     <label>
-                        <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.bonus.degats" 
+                        <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.bonus.degats"
                         value="{{this.impulsions.guerre.bonus.degats}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
@@ -240,7 +240,7 @@
                 <div class="longspan">
                     <span>{{localize "KNIGHT.BONUS.Violence"}}</span>
                     <label>
-                        <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.bonus.violence" 
+                        <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.bonus.violence"
                         value="{{this.impulsions.guerre.bonus.violence}}"
                         min="0"
                         {{#if this.softlock}}disabled{{/if}} />
@@ -250,22 +250,22 @@
                 <h4>{{localize "KNIGHT.LATERAL.Energie"}}</h4>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Allie"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.allie" 
-                    value="{{this.impulsions.guerre.energie.allie}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.allie"
+                    value="{{this.impulsions.guerre.energie.allie}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan noBorderTop">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.Porteur"}}</span>
-                    <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.porteur" 
-                    value="{{this.impulsions.guerre.energie.porteur}}" 
+                    <input type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.porteur"
+                    value="{{this.impulsions.guerre.energie.porteur}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
                 <label class="longspan">
                     <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WARLORD.IMPULSIONS.AlliesPorteur"}}</span>
-                    <input class="absolute" type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.prolonger" 
-                    value="{{this.impulsions.guerre.energie.prolonger}}" 
+                    <input class="absolute" type="number" name="system.capacites.selected.warlord.impulsions.guerre.energie.prolonger"
+                    value="{{this.impulsions.guerre.energie.prolonger}}"
                     min="0"
                     {{#if this.softlock}}disabled{{/if}} />
                 </label>
@@ -283,7 +283,7 @@
                 <label class="shortspan">
                     <span>{{localize "KNIGHT.DUREE.Label"}}</span>
                     <textarea name="system.capacites.selected.warlord.impulsions.guerre.duree"
-                    data-capacite="warlord" data-type="dureeGuerre" data-min="50" style="height:{{this.textarea.dureeGuerre}}px;" 
+                    data-capacite="warlord" data-type="dureeGuerre" data-min="50" style="height:{{this.textarea.dureeGuerre}}px;"
                     {{#if this.softlock}}disabled{{/if}}>{{this.impulsions.guerre.duree}}</textarea>
                 </label>
             </div>

--- a/templates/items/armuresLegende/capacites/windtalker.html
+++ b/templates/items/armuresLegende/capacites/windtalker.html
@@ -1,6 +1,6 @@
 
 <div class="windtalker">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.WINDTALKER.Label"}}
         <div>
@@ -24,13 +24,13 @@
         <div class="data">
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Flux"}}</span>
-                <input type="number" name="system.capacites.selected.windtalker.flux" value="{{this.flux}}" 
+                <input type="number" name="system.capacites.selected.windtalker.flux" value="{{this.flux}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>
             <label class="shortspan">
                 <span>{{localize "KNIGHT.LATERAL.Energie"}}</span>
-                <input type="number" name="system.capacites.selected.windtalker.energie" value="{{this.energie}}" 
+                <input type="number" name="system.capacites.selected.windtalker.energie" value="{{this.energie}}"
                 {{#if this.softlock}}disabled{{/if}}
                 />
             </label>

--- a/templates/items/armuresLegende/special/recolteflux.html
+++ b/templates/items/armuresLegende/special/recolteflux.html
@@ -1,5 +1,5 @@
 <div class="recolteflux">
-    <h3 class="header">
+    <h3 class="header js-toggler">
         <i class="far fa-minus-square"></i>
         {{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.Label"}}
         <div>
@@ -24,15 +24,15 @@
             <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXHORSCONFLIT.Label"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXHORSCONFLIT.FluxParCreature"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.horsconflit.base" 
-                value="{{this.horsconflit.base}}" 
+                <input type="number" name="system.special.selected.recolteflux.horsconflit.base"
+                value="{{this.horsconflit.base}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.AUTRE.Limite"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.horsconflit.limite" 
-                value="{{this.horsconflit.limite}}" 
+                <input type="number" name="system.special.selected.recolteflux.horsconflit.limite"
+                value="{{this.horsconflit.limite}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
@@ -55,36 +55,36 @@
             <h4 class="title">{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.Label"}}</h4>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.DebutConflit"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.base" 
-                value="{{this.conflit.base}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.base"
+                value="{{this.conflit.base}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.ParTour"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.tour" 
-                value="{{this.conflit.tour}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.tour"
+                value="{{this.conflit.tour}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.ParHostile"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.hostile" 
-                value="{{this.conflit.hostile}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.hostile"
+                value="{{this.conflit.hostile}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.ParSalopard"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.salopard" 
-                value="{{this.conflit.salopard}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.salopard"
+                value="{{this.conflit.salopard}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>
             <label class="longspan">
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.SPECIAL.RECOLTEFLUX.FLUXENCONFLIT.ParPatron"}}</span>
-                <input type="number" name="system.special.selected.recolteflux.conflit.patron" 
-                value="{{this.conflit.patron}}" 
+                <input type="number" name="system.special.selected.recolteflux.conflit.patron"
+                value="{{this.conflit.patron}}"
                 min="0"
                 {{#if this.softlock}}disabled{{/if}} />
             </label>

--- a/templates/items/module-sheet.html
+++ b/templates/items/module-sheet.html
@@ -4,12 +4,12 @@
             <input name="name" type="text" value="{{data.name}}" placeholder="{{localize "KNIGHT.Nom"}}" />
         </h1>
     </header>
-    
+
      <div class="main">
         <div class="blockImg">
             <img class="profile-img" src="{{data.img}}" data-edit="img" title="{{data.name}}" />
         </div>
-        
+
         <div class="description">
             <h2 class="header">{{localize "KNIGHT.Description"}}</h2>
 
@@ -17,7 +17,7 @@
         </div>
 
         <div class="fullData">
-            <h2 class="header">
+            <h2 class="header js-toggler">
                 <i class="far fa-minus-square"></i>
                 {{localize "KNIGHT.ITEMS.ARMURE.SLOTS.Label"}}
             </h2>
@@ -109,7 +109,7 @@
                 <span>{{localize "KNIGHT.AUTRE.PointGloire"}}</span>
                 <input type="number" name="system.prix" value="{{systemData.prix}}" min="0" />
             </label>
-    
+
             <div class="twoLine">
                 <span>
                     {{localize "KNIGHT.LATERAL.Energie"}}
@@ -211,7 +211,7 @@
     </div>
 
     <div class="main bonus {{#unless systemData.bonus.has}}hidden{{/unless}}">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.BONUS.Label"}}
         </h2>
@@ -267,7 +267,7 @@
                 unactive
                 {{/if}}
                 " data-type="bonus" data-subtype="grenades" data-name="has" data-value="{{systemData.bonus.grenades.has}}">{{systemData.labels.bonusGrenades}}</button>
-    
+
                 {{#each systemData.bonus.grenades.liste  as | key grenade|}}
                     <h3 class="title {{#unless @root/systemData/bonus/grenades/has}}hidden{{/unless}}">{{getGrenadeName grenade}}</h3>
                     <label class="oneLinewOnlyDice {{#unless @root/systemData/bonus/grenades/has}}hidden{{/unless}}">
@@ -290,7 +290,7 @@
 
         <div class="col">
             <div class="twoLine">
-                <button type="action" class="button 
+                <button type="action" class="button
                 {{#if systemData.bonus.degats.has}}
                 active
                 {{else}}
@@ -342,7 +342,7 @@
                     <input type="number" name="system.bonus.degats.variable.max.fixe" value="{{systemData.bonus.degats.variable.max.fixe}}" min="{{systemData.bonus.degats.variable.min.fixe}}" />
                 </div>
             </div>
-            
+
             <div class="twoLine">
                 <button type="action" class="button
                 {{#if systemData.bonus.violence.has}}
@@ -409,7 +409,7 @@
         </div>
 
         <div class="main overdrives {{#unless systemData.bonus.overdrives.has}}hidden{{/unless}}">
-            <h2 class="header">
+            <h2 class="header js-toggler">
                 <i class="far fa-minus-square"></i>
                 {{localize "KNIGHT.ITEMS.MODULE.OVERDRIVES.Labelbonus"}}
             </h2>
@@ -429,7 +429,7 @@
     </div>
 
     <div class="main arme {{#unless systemData.arme.has}}hidden{{/unless}}">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.MODULE.ARME.Label"}}
         </h2>
@@ -493,7 +493,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <div class="twoLine">
                 <button type="action" class="button borderTop noBorderBottom
                 {{#if systemData.arme.violence.variable.has}}
@@ -606,7 +606,7 @@
     </div>
 
     <div class="main pnj {{#unless systemData.pnj.has}}hidden{{/unless}}">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{systemData.labels.pnjTitle}}
 
@@ -821,7 +821,7 @@
                                     <a class="edit" data-path="system.pnj.liste.{{pnj}}.armes.liste.{{arme}}.effets">
                                         <span>{{localize "KNIGHT.EFFETS.Edit"}}</span>
                                     </a>
-                                </div>       
+                                </div>
                             </div>
                         {{/each}}
                     </div>
@@ -860,7 +860,7 @@
     </div>
 
     <div class="main overdrives {{#unless systemData.overdrives.has}}hidden{{/unless}}">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.MODULE.OVERDRIVES.Label"}}
         </h2>
@@ -879,7 +879,7 @@
     </div>
 
     <div class="main rogue {{#unless systemData.ersatz.rogue.has}}hidden{{/unless}}">
-        <h2 class="header">
+        <h2 class="header js-toggler">
             <i class="far fa-minus-square"></i>
             {{localize "KNIGHT.ITEMS.MODULE.ERSATZ.ROGUE.Label"}}
         </h2>
@@ -889,7 +889,7 @@
                 <span>{{localize "KNIGHT.ITEMS.ARMURE.CAPACITES.GHOST.BonusPasserInaperçu"}}</span>
                 <input type="number" name="system.ersatz.rogue.reussites" value="{{systemData.ersatz.rogue.reussites}}" min="0" />
             </label>
-            
+
             <div class="oneLine">
                 <button type="action" class="button {{#if systemData.ersatz.rogue.interruption.actif}}active{{/if}}"
                 data-type="ersatz" data-subtype="rogue" data-name="interruption" data-subname="actif" data-value="{{systemData.ersatz.rogue.interruption.actif}}">
@@ -900,7 +900,7 @@
                     {{/if}}
                 </button>
             </div>
-            
+
             <label class="oneLine">
                 <span>{{localize "KNIGHT.BONUS.Attaque"}}</span>
                 <select name="system.ersatz.rogue.attaque">
@@ -954,7 +954,7 @@
                     {{localize "KNIGHT.NOINCLUS.Dice"}}
                     {{/if}}
                 </button>
-                
+
                 <button type="action" class="button {{#if systemData.ersatz.rogue.degats.fixe}}active{{/if}}"
                 data-type="ersatz" data-subtype="rogue" data-name="degats" data-subname="fixe" data-value="{{systemData.ersatz.rogue.degats.fixe}}">
                     {{#if systemData.ersatz.rogue.degats.fixe}}


### PR DESCRIPTION
Afin de mettre en place des panels pliants/dépliants, tu dois ajouter cette ligne dans la méthode `activateListeners(html)` des `sheet.mjs` : `toggler.init(this.id, html);`. Toujours fournir les deux même argument, ils ne changent jamais.

Il n'y a donc plus besoin de déclarer les clics sur `html.find('.header .far').click(ev => {});` ou `html.find('.extendButton').click(ev => {});`.

Il faut également bien veiller à ce que la lib' soit importée en haut du fichier : `import toggler from '../../helpers/toggler.js';` C'est généralement fait tout seul par l'IDE.


Ensuite, sur les templates `html`, il faut ajouter la classe `js-toggler` sur l'élément de header servant de "titre" aux panels. Tu peux voir tout un tas d'exemple dans la PR.


Pour résumer simplement, la mise en place se fait en deux étapes : 
1. Ajouter `toggler.init(this.id, html);` dans la méthode `activateListeners(html)`
2. Ajouter la classe `js-toggler` sur l'élément de header des panels

J'ai modifié tous les panels déjà en place.


L'état des panels est stocké dans le `localStorage` du navigateur. J'ai mis en place un hook lorsque l'on supprime un `Item` ou un `Actor` afin d'aller supprimer les données qui le concerne du `localStorage`.
J'ai également ajouté une option dans le système, de type client, qui permet de vider complètement les états enregistrés sur toutes les fiches afin que tout revienne à l'état "d'origine".