### PR TITLE
Correction nombre de langues connues.

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -565,7 +565,7 @@ export class KnightActor extends Actor {
     data.defense.value = Math.max(userDBase+defenseBonus-defenseMalus, 0);
 
     // LANGUES
-    const userLBase = Math.max(data.aspects.machine.caracteristiques.savoir.value-2, 1);
+    const userLBase = Math.max(data.aspects.machine.caracteristiques.savoir.value-1, 1);
     const userLBonus = data.langues.mod;
 
     data.langues.value = userLBase+userLBonus;


### PR DESCRIPTION
Le LdB spécifie "Chaque point de Savoir au-delà de 2 représente une langue supplémentaire"
Un perso à 2 de savoir aura donc 1 langue
Un perso à 3 en aura 2. 
Or le code actuel donnait 1 seule langue pour un perso à 3 de savoir Math.max entre 3-2 et 1 : résultat 1.